### PR TITLE
PR-US1.2: Basic Player Profile (Intensity + Reliability Score)

### DIFF
--- a/playlocal/backend/src/test/java/com/backend/playlocal/unit/ProfileIntensityTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/unit/ProfileIntensityTest.java
@@ -1,0 +1,181 @@
+package com.backend.playlocal.unit;
+
+import com.backend.playlocal.model.dto.AuthDto;
+import com.backend.playlocal.model.dto.UserDto;
+import com.backend.playlocal.model.entity.User;
+import com.backend.playlocal.repository.UserRepository;
+import com.backend.playlocal.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for US 1.2 - Basic player profile (Intensity + Reliability Score).
+ * 
+ * Tests cover:
+ * 1. Intensity value validation (Beginner/Casual/Competitive)
+ * 2. Reliability score is read-only and cannot be modified via client input
+ * 3. Profile updates persist correctly
+ */
+@ExtendWith(MockitoExtension.class)
+class ProfileIntensityTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    private User user;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .displayName("Test User")
+                .status(User.UserStatus.ACTIVE)
+                .reliabilityScore(85.0f)
+                .attendedCount(17)
+                .noShowCount(3)
+                .gamesCount(20)
+                .defaultIntensity("beginner")
+                .build();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "beginner", "casual", "competitive" })
+    @DisplayName("US-1.2: updateProfile accepts valid intensity values")
+    void updateProfile_WithValidIntensity_Success(String intensity) {
+        // Given
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserDto.UpdateProfileRequest request = UserDto.UpdateProfileRequest.builder()
+                .defaultIntensity(intensity)
+                .build();
+
+        // When
+        AuthDto.UserDto result = userService.updateProfile(userId.toString(), request);
+
+        // Then
+        assertThat(result.getDefaultIntensity()).isEqualTo(intensity);
+        verify(userRepository).save(argThat(savedUser -> savedUser.getDefaultIntensity().equals(intensity)));
+    }
+
+    @Test
+    @DisplayName("US-1.2: updateProfile with displayName and intensity persists both")
+    void updateProfile_WithDisplayNameAndIntensity_BothPersist() {
+        // Given
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserDto.UpdateProfileRequest request = UserDto.UpdateProfileRequest.builder()
+                .displayName("New Name")
+                .defaultIntensity("competitive")
+                .build();
+
+        // When
+        AuthDto.UserDto result = userService.updateProfile(userId.toString(), request);
+
+        // Then
+        assertThat(result.getDisplayName()).isEqualTo("New Name");
+        assertThat(result.getDefaultIntensity()).isEqualTo("competitive");
+        verify(userRepository).save(argThat(savedUser -> savedUser.getDisplayName().equals("New Name") &&
+                savedUser.getDefaultIntensity().equals("competitive")));
+    }
+
+    @Test
+    @DisplayName("US-1.2: Reliability score remains unchanged after profile update")
+    void updateProfile_ReliabilityScoreUnchanged() {
+        // Given: User has a specific reliability score
+        float originalScore = 85.0f;
+        user.setReliabilityScore(originalScore);
+
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When: Update profile with displayName and intensity
+        UserDto.UpdateProfileRequest request = UserDto.UpdateProfileRequest.builder()
+                .displayName("Updated Name")
+                .defaultIntensity("casual")
+                .build();
+
+        AuthDto.UserDto result = userService.updateProfile(userId.toString(), request);
+
+        // Then: Reliability score should remain unchanged
+        assertThat(result.getReliabilityScore()).isEqualTo(originalScore);
+        verify(userRepository).save(argThat(savedUser -> savedUser.getReliabilityScore().equals(originalScore)));
+    }
+
+    @Test
+    @DisplayName("US-1.2: Profile response includes reliability score (read-only display)")
+    void getUserProfile_IncludesReliabilityScore() {
+        // Given
+        float expectedScore = 92.5f;
+        user.setReliabilityScore(expectedScore);
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        AuthDto.UserDto result = userService.getUserProfile(userId.toString());
+
+        // Then
+        assertThat(result.getReliabilityScore()).isEqualTo(expectedScore);
+    }
+
+    @Test
+    @DisplayName("US-1.2: Profile response includes all required fields")
+    void getUserProfile_IncludesAllRequiredFields() {
+        // Given
+        user.setDisplayName("Test Player");
+        user.setDefaultIntensity("competitive");
+        user.setReliabilityScore(88.0f);
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        AuthDto.UserDto result = userService.getUserProfile(userId.toString());
+
+        // Then: Acceptance Criteria - Profile shows: display name, self-rated
+        // intensity, and Reliability Score
+        assertThat(result.getDisplayName()).isEqualTo("Test Player");
+        assertThat(result.getDefaultIntensity()).isEqualTo("competitive");
+        assertThat(result.getReliabilityScore()).isEqualTo(88.0f);
+    }
+
+    @Test
+    @DisplayName("US-1.2: UpdateProfileRequest DTO does not have reliabilityScore field")
+    void updateProfileRequest_DoesNotHaveReliabilityScoreField() {
+        // This test verifies the design decision that reliabilityScore cannot be set
+        // via client input
+        // by confirming the UpdateProfileRequest DTO does not expose this field
+
+        UserDto.UpdateProfileRequest request = UserDto.UpdateProfileRequest.builder()
+                .displayName("Test")
+                .defaultIntensity("casual")
+                .bio("Bio")
+                .location("Montreal")
+                .availability("weekends")
+                .phone("+1234567890")
+                .build();
+
+        // Verify we can build the request without a reliabilityScore field
+        // The absence of a setter/builder method is verified by compilation
+        assertThat(request).isNotNull();
+        assertThat(request.getDisplayName()).isEqualTo("Test");
+    }
+}

--- a/playlocal/frontend/components/GameRoom.tsx
+++ b/playlocal/frontend/components/GameRoom.tsx
@@ -306,7 +306,12 @@ export function GameRoom() {
                             </div>
                             <div className="flex-1 min-w-0">
                               <div className="flex items-center gap-2">
-                                <span className="text-gray-900 truncate">{player.displayName}</span>
+                                <Link
+                                  href={`/profile/${player.displayName?.toLowerCase().replace(/\s+/g, '-') || player.userId}`}
+                                  className="text-gray-900 truncate hover:text-emerald-600 transition-colors"
+                                >
+                                  {player.displayName}
+                                </Link>
                                 {player.role === 'ORGANIZER' && (
                                   <span className="px-2 py-0.5 bg-emerald-100 text-emerald-700 text-xs rounded">Host</span>
                                 )}
@@ -336,7 +341,12 @@ export function GameRoom() {
                                   {player.displayName?.[0] || '?'}
                                 </div>
                                 <div>
-                                  <div className="text-gray-900">{player.displayName}</div>
+                                  <Link
+                                    href={`/profile/${player.displayName?.toLowerCase().replace(/\s+/g, '-') || player.userId}`}
+                                    className="text-gray-900 hover:text-emerald-600 transition-colors"
+                                  >
+                                    {player.displayName}
+                                  </Link>
                                   <div className="text-sm text-gray-600">
                                     Reliability: {player.reliabilityScore}%
                                   </div>


### PR DESCRIPTION
## Pull Request

### Description

Implements **US 1.2 – Basic Player Profile** with the following functionality:

* Profile displays **display name**, **self-rated intensity** (Beginner/Casual/Competitive), and **Reliability Score**
* User can edit **display name** and **intensity**; changes persist and re-render on refresh
* **Reliability Score is read-only** in the UI and cannot be edited via client inputs
* Profile is accessible from **top navigation** and by clicking a user in a **roster**
* Closes **#US-1.2**

---

### Type of Change

* [ ] Bug fix
* [x] New feature (User Story)
* [ ] Task implementation
* [ ] Documentation update
* [ ] Code refactoring
* [x] Unit tests
* [ ] Other (please describe): ______________________

---

### Related Issues

* **Implements:** #US-1.2
* **Related to:** #US-1.1 (Register/Login)
* **Related to:** #US-2.4 (Game Page with Roster)

---

## All Relevant Files

### Frontend Components

| File                                  | Purpose                | Key Code                                   |
| ------------------------------------- | ---------------------- | ------------------------------------------ |
| `frontend/components/UserProfile.tsx` | Profile display        | Line 209: `reliabilityScore` display       |
| `frontend/components/EditProfile.tsx` | Profile editing        | Lines 168–188: Read-only reliability score |
| `frontend/components/GameRoom.tsx`    | Roster → profile links | Lines 309–314, 344–349: Player name links  |
| `frontend/components/Navigation.tsx`  | Profile nav link       | Profile button in header                   |

### Frontend Infrastructure

| File                               | Purpose           | Key Code                               |
| ---------------------------------- | ----------------- | -------------------------------------- |
| `frontend/lib/constants.ts`        | Intensity options | `beginner`, `casual`, `competitive`    |
| `frontend/lib/api.ts`              | API calls         | `usersApi.updateProfile()`             |
| `frontend/context/AuthContext.tsx` | User data         | `reliabilityScore`, `defaultIntensity` |

### Frontend Routes

| File                                       | Purpose                  |
| ------------------------------------------ | ------------------------ |
| `frontend/app/profile/page.tsx`            | Own profile route        |
| `frontend/app/profile/[username]/page.tsx` | Other user profile route |
| `frontend/app/profile/edit/page.tsx`       | Edit profile route       |

### Backend Entity & DTOs

| File                                 | Purpose        | Key Code                                              |
| ------------------------------------ | -------------- | ----------------------------------------------------- |
| `backend/.../model/entity/User.java` | User entity    | `displayName`, `defaultIntensity`, `reliabilityScore` |
| `backend/.../model/dto/UserDto.java` | Update request | Excludes `reliabilityScore` (read-only by design)     |
| `backend/.../model/dto/AuthDto.java` | Response DTO   | Includes all profile fields                           |

### Backend Services & Controllers

| File                                         | Purpose       | Key Code                              |
| -------------------------------------------- | ------------- | ------------------------------------- |
| `backend/.../service/UserService.java`       | Profile logic | `updateProfile()`, `getUserProfile()` |
| `backend/.../controller/UserController.java` | API endpoints | `/profile`, `/users/{id}/profile`     |
| `backend/.../repository/UserRepository.java` | Data access   | `findActiveById()`                    |

### Backend Tests

| File                                             | Purpose                     |
| ------------------------------------------------ | --------------------------- |
| `backend/.../test/.../ProfileIntensityTest.java` | US 1.2 unit tests (6 tests) |
| `backend/.../test/.../UserServiceTest.java`      | Service layer tests         |
| `backend/.../test/.../UserControllerTest.java`   | Controller tests            |

---

## Requirements Reference (Mandatory for User Stories)

View all requirements in the Project Requirements

**Requirement Reference:** `REQ-IDENTITY-002`, `REQ-RELIABILITY-001`

### Justification

* **REQ-IDENTITY-002:** Profile displays user identity fields (display name, intensity preference)
* **REQ-RELIABILITY-001:** Reliability Score is calculated server-side and displayed read-only to prevent manipulation

---

## Risk Mitigation (Mandatory for User Stories)

### Associated Risks

* **Client-side score manipulation** — Users attempting to modify reliability score via API
* **Profile data inconsistency** — Edits not persisting after refresh

**Mitigation Strategy:** Fix now

### Details

| Risk               | Mitigation                                                                                                                                                                                       |
| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| Score manipulation | `UserDto.UpdateProfileRequest` excludes `reliabilityScore` entirely. `UserService.updateProfile()` never modifies the score. Unit test `updateProfile_ReliabilityScoreUnchanged` validates this. |
| Data inconsistency | `AuthContext.refreshUser()` is called after save. Changes persist via API and re-fetch on page load.                                                                                             |

---

## Technical Requirements

* [x] Code follows project standards and guidelines
* [x] Architecture unchanged (profile already part of User entity)

---

## Unit Tests

**Unit Test Status:** Completed ✅

**Test Command:**

```bash
cd playlocal/backend && ./mvnw test -Dtest=ProfileIntensityTest,UserServiceTest
```

* [x] Unit tests written (6 new tests in `ProfileIntensityTest.java`)
* [x] Code coverage >80% on `UserService`
* [x] Unit tests documented
* [x] All tests passing

### Test Coverage

| Test                                                    | What It Verifies                       |
| ------------------------------------------------------- | -------------------------------------- |
| `updateProfile_WithValidIntensity_Success`              | Accepts beginner/casual/competitive    |
| `updateProfile_WithDisplayNameAndIntensity_BothPersist` | Both fields save correctly             |
| `updateProfile_ReliabilityScoreUnchanged`               | Score cannot be modified via update    |
| `getUserProfile_IncludesReliabilityScore`               | Profile response includes score        |
| `getUserProfile_IncludesAllRequiredFields`              | Display name, intensity, score present |
| `updateProfileRequest_DoesNotHaveReliabilityScoreField` | DTO design prevents score editing      |

---

## Acceptance Criteria Validation

| Criteria                                           | Status | Evidence                                     |
| -------------------------------------------------- | ------ | -------------------------------------------- |
| Profile shows display name, intensity, reliability | ✅      | `UserProfile.tsx` StatCard components        |
| User can edit display name + intensity             | ✅      | `EditProfile.tsx` form with save             |
| Changes persist on refresh                         | ✅      | API integration + AuthContext refresh        |
| Reliability Score is read-only                     | ✅      | No field in DTO, UI shows “cannot be edited” |
| Profile from navigation                            | ✅      | `Navigation.tsx` profile button              |
| Profile from roster click                          | ✅      | `GameRoom.tsx` link on player names          |

---

## Customer Signoff

* [x] Requirements reviewed with customer/stakeholder
* [x] Acceptance criteria approved
* [x] Customer signoff received

---

## Definition of Done

* [x] Code implemented and follows standards
* [x] Risk mitigation addressed
* [x] Documentation updated
* [x] Story tagged in git when completed
* [x] PR reviewed and risks audited

---

## Demo

https://github.com/user-attachments/assets/fa376fb0-6ba0-483e-9086-26236f0b7150


---

## Additional Notes

* Reliability Score calculation is handled by `ReliabilityService.java` (US 2.7)
* Profile accessible at `/profile` (own) and `/profile/{username}` (others)
* Intensity options defined in `constants.ts` for consistency


