### PR TITLE
fix: Round reliability score display and refresh on profile load

### DIFF
--- a/playlocal/frontend/components/EditProfile.tsx
+++ b/playlocal/frontend/components/EditProfile.tsx
@@ -174,7 +174,7 @@ export function EditProfile() {
                                 <div className="flex items-center justify-between">
                                     <div className="flex items-center gap-2">
                                         <span className="text-3xl font-bold text-emerald-600">
-                                            {user?.reliabilityScore || 100}%
+                                            {Math.round(user?.reliabilityScore ?? 100)}%
                                         </span>
                                         <CheckCircle className="w-6 h-6 text-emerald-500" />
                                     </div>

--- a/playlocal/frontend/components/GameRoom.tsx
+++ b/playlocal/frontend/components/GameRoom.tsx
@@ -649,7 +649,7 @@ export function GameRoom() {
                               </div>
                               <div className="flex items-center gap-2 text-sm">
                                 <span className="text-gray-600">
-                                  Reliability: {player.reliabilityScore}%
+                                  Reliability: {Math.round(player.reliabilityScore)}%
                                 </span>
                               </div>
                             </div>
@@ -705,7 +705,7 @@ export function GameRoom() {
                                     {player.displayName}
                                   </Link>
                                   <div className="text-sm text-gray-600">
-                                    Reliability: {player.reliabilityScore}%
+                                    Reliability: {Math.round(player.reliabilityScore)}%
                                   </div>
                                 </div>
                               </div>
@@ -900,7 +900,7 @@ export function GameRoom() {
                   <div className="flex items-center gap-1 mb-2">
                     <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
                     <span className="text-sm text-gray-600">
-                      Reliability: {game.organizer?.reliabilityScore || 100}%
+                      Reliability: {Math.round(game.organizer?.reliabilityScore ?? 100)}%
                     </span>
                   </div>
                   <Link

--- a/playlocal/frontend/components/UserProfile.tsx
+++ b/playlocal/frontend/components/UserProfile.tsx
@@ -16,7 +16,7 @@ import { OrganizerQualityBadge } from './OrganizerQualityBadge';
 export function UserProfile() {
   const { username } = useParams();
   const usernameStr = Array.isArray(username) ? username[0] : username;
-  const { user: currentUser, isAuthenticated } = useAuth();
+  const { user: currentUser, isAuthenticated, refreshUser } = useAuth();
   const [activeTab, setActiveTab] = useState<'overview' | 'sports' | 'history' | 'stats' | 'score-history'>('overview');
   const [showReportModal, setShowReportModal] = useState(false);
   const [otherUser, setOtherUser] = useState<UserDto | null>(null);
@@ -57,6 +57,13 @@ export function UserProfile() {
       fetchData();
     }
   }, [isOwnProfile, usernameStr]);
+
+  // Refresh auth user data when viewing own profile so stats are up-to-date
+  useEffect(() => {
+    if (isOwnProfile) {
+      refreshUser();
+    }
+  }, [isOwnProfile]);
 
   // TODO: Implement friendship check via API
   const isFriend = false; // Placeholder for friendship status
@@ -298,7 +305,7 @@ export function UserProfile() {
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
             <StatCard label="Games Played" value={user.stats.gamesPlayed} />
             <StatCard label="Games Hosted" value={user.stats.gamesHosted} />
-            <StatCard label="Reliability Score" value={`${user.stats.reliabilityScore}%`} />
+            <StatCard label="Reliability Score" value={`${Math.round(user.stats.reliabilityScore)}%`} />
             {/* US 3.3 Organizer Endorsements */}
             <StatCard label="Endorsements" value={endorsements.length} icon={<Medal className="w-4 h-4 text-emerald-600" />} />
             <StatCard label="Average Rating" value={user.stats.averageRating} icon={<Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />} />

--- a/playlocal/frontend/test/UserProfileEndorsement.test.tsx
+++ b/playlocal/frontend/test/UserProfileEndorsement.test.tsx
@@ -74,6 +74,7 @@ describe('UserProfile Endorsements', () => {
     (useAuth as jest.Mock).mockReturnValue({
       user: mockUser,
       isAuthenticated: true,
+      refreshUser: jest.fn(),
     });
     (usersApi.getProfile as jest.Mock).mockResolvedValue(mockUser);
     (usersApi.getProfileBySlug as jest.Mock).mockResolvedValue(mockUser);
@@ -132,5 +133,23 @@ describe('UserProfile Endorsements', () => {
     });
 
     expect(screen.getByText('No endorsements yet')).toBeInTheDocument();
+  });
+
+  it('calls refreshUser when viewing own profile', async () => {
+    const mockRefreshUser = jest.fn();
+    // Override useParams to match the mock user's slug (Test User -> test-user)
+    jest.spyOn(require('next/navigation'), 'useParams').mockReturnValue({ username: 'test-user' });
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      isAuthenticated: true,
+      refreshUser: mockRefreshUser,
+    });
+    (endorsementsApi.getUserEndorsements as jest.Mock).mockResolvedValue([]);
+
+    render(<UserProfile />);
+
+    await waitFor(() => {
+      expect(mockRefreshUser).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Fix reliability score display across multiple frontend components. Scores were showing floating point artifacts (e.g. `60.000004%` instead of `60%`) and the profile header was showing stale data from login time.

Closes #176, #177

## Type of Change

- [x] Bug fix
- [ ] New feature (User Story)
- [ ] Task implementation
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Unit tests
- [ ] Other (please describe)

## Related Issues

- Fixes: #176
- Fixes: #177 

## Screenshots
<img width="1470" height="956" alt="Screenshot 2026-02-01 at 14 42 53" src="https://github.com/user-attachments/assets/0a24a30e-0b8c-4269-9166-13e762d43ef7" />
