### PR TITLE
Us11.11

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,22 @@
+# Copy this file to .env.prod and replace placeholder values before running
+# docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+
+POSTGRES_DB=playlocal
+POSTGRES_USER=playlocal
+POSTGRES_PASSWORD=replace-with-strong-db-password
+BACKEND_PORT=8080
+
+JWT_SECRET=replace-with-strong-jwt-secret-at-least-32-chars
+JWT_EXPIRATION=86400000
+
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=replace-with-strong-minio-password
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=replace-with-strong-minio-password
+S3_BUCKET_NAME=uploads
+AWS_REGION=us-east-1
+S3_ENDPOINT=http://minio:9000
+S3_PUBLIC_ENDPOINT=http://localhost:9000
+S3_FORCE_PATH_STYLE=true
+
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=YOUR_API_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ rand.md
 # Environment variables
 # Never commit secrets or environment-specific configurations.
 .env
+.env.prod
 *.env
 *.env.local
 !/.env.example

--- a/README.md
+++ b/README.md
@@ -112,6 +112,35 @@ docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod
 docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml down
 ```
 
+### Dev vs Production Compose Differences
+
+| Area | Development (`docker-compose.yml`) | Production-oriented (`docker-compose.prod.yml`) |
+| --- | --- | --- |
+| Backend profile | `SPRING_PROFILES_ACTIVE=dev` | `SPRING_PROFILES_ACTIVE=prod` |
+| Secrets and env | Local defaults are embedded for convenience | Sensitive values are expected from `.env.prod` |
+| Restart behavior | No restart policy | `restart: unless-stopped` for long-running services |
+| MinIO configuration | Dev console enabled and fixed local credentials | Runtime command is simplified and credentials/bucket come from env values |
+| Migration strictness | Flyway validation disabled for local velocity | Flyway validation enabled for production-like startup checks |
+
+### Reviewer Quick Check
+
+1. Verify the production override resolves correctly:
+```sh
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml config
+```
+2. Start production-oriented services:
+```sh
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+```
+3. Confirm backend health:
+```sh
+curl http://localhost:8080/api/v1/health
+```
+4. Stop the stack:
+```sh
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml down
+```
+
 ### Manual Development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -75,11 +75,36 @@ docker compose up --build
 
 - **Frontend**: http://localhost:3000
 - **Backend**: http://localhost:8080
-- **Database**: localhost:5432
+- **Database**: localhost:5439
 
 To stop the services:
 ```sh
 docker compose down
+```
+
+### Docker Production-Oriented Configuration
+
+Use the production override when you want behavior closer to deployment (production Spring profile, env-driven secrets, and restart policies).
+
+Use the base file (`docker-compose.yml`) for local development defaults.
+Use the production setup (`docker-compose.yml` + `docker-compose.prod.yml`) for production-like runtime behavior.
+
+1. Create a production env file from the template:
+```sh
+cp .env.prod.example .env.prod
+```
+
+2. Update `.env.prod` with real secrets and environment values.
+   `.env.prod` is ignored by Git, so secrets stay local by default.
+
+3. Start the production-oriented stack:
+```sh
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+```
+
+4. Stop the production-oriented stack:
+```sh
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml down
 ```
 
 ### Manual Development

--- a/README.md
+++ b/README.md
@@ -97,12 +97,17 @@ cp .env.prod.example .env.prod
 2. Update `.env.prod` with real secrets and environment values.
    `.env.prod` is ignored by Git, so secrets stay local by default.
 
-3. Start the production-oriented stack:
+3. If you are reusing old Docker volumes with different DB credentials, reset them first:
+```sh
+docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml down -v
+```
+
+4. Start the production-oriented stack:
 ```sh
 docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml up --build -d
 ```
 
-4. Stop the production-oriented stack:
+5. Stop the production-oriented stack:
 ```sh
 docker compose --env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml down
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,53 @@
+services:
+  postgres:
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-playlocal}
+      POSTGRES_USER: ${POSTGRES_USER:-playlocal}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.prod}
+
+  minio:
+    restart: unless-stopped
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env.prod}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env.prod}
+
+  minio_init:
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD};
+      mc mb -p local/${S3_BUCKET_NAME:-uploads} || true;
+      mc anonymous set none local/${S3_BUCKET_NAME:-uploads} || true;
+      echo 'MinIO bucket ready';
+      "
+
+  backend:
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-playlocal}
+      DATABASE_USERNAME: ${POSTGRES_USER:-playlocal}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.prod}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env.prod}
+      JWT_EXPIRATION: ${JWT_EXPIRATION:-86400000}
+      PORT: ${BACKEND_PORT:-8080}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME:-uploads}
+      S3_BUCKET: ${S3_BUCKET_NAME:-uploads}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      S3_REGION: ${AWS_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?set AWS_ACCESS_KEY_ID in .env.prod}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?set AWS_SECRET_ACCESS_KEY in .env.prod}
+      S3_ACCESS_KEY: ${AWS_ACCESS_KEY_ID:?set AWS_ACCESS_KEY_ID in .env.prod}
+      S3_SECRET_KEY: ${AWS_SECRET_ACCESS_KEY:?set AWS_SECRET_ACCESS_KEY in .env.prod}
+      endpoint: ${S3_ENDPOINT:-http://minio:9000}
+      publicEndpoint: ${S3_PUBLIC_ENDPOINT:-http://localhost:9000}
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-true}
+      SPRING_FLYWAY_VALIDATE_ON_MIGRATE: "true"
+
+  frontend:
+    restart: unless-stopped
+    build:
+      args:
+        NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}


### PR DESCRIPTION

---
name: US11.11
about: Pull request template
title: 'PR-US11.11: Add production compose override and align env handling in dev compose'
assignees: @Omare04 

---

# Pull Request

## Description

Adds a new `docker-compose.prod.yml` override for production deployment parity and updates `docker-compose.yml` (dev) to avoid duplicate frontend environment injection for `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` by relying on build args.

Key changes:
- Added production-specific restart policies (`unless-stopped`) for long-running services.
- Added required/validated production environment variables for Postgres, MinIO, backend JWT/DB/S3 config.
- Added MinIO init behavior in prod override to ensure bucket creation and access policy setup.
- Added frontend prod build arg pass-through for `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`.
- Removed redundant frontend runtime `environment` block in dev compose that duplicated the maps key.

Closes: N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature (User Story)
- [x] Task implementation
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Unit tests
- [x] Other (please describe): Dev/prod Docker Compose configuration and deployment parity improvements

## Requirements Reference [Mandatory for User Stories]

View all requirements in the [Project Requirements](https://github.com/munera-intelligence/PermitParser/wiki/Project-Requirements)

**Justification:** This PR focuses on environment consistency and deployability between development and production Compose configurations.

## Risk Mitigation [Mandatory for User Stories]

**Associated Risks:** Misconfigured production env vars, service restart behavior, storage bootstrapping mismatch.

**Mitigation Strategy:** Fix now (explicit required env validation + deterministic prod overrides).

**Details:**
- Required secrets now fail fast via `${VAR:?set ...}` in `docker-compose.prod.yml`.
- Restart policy set to `unless-stopped` for better runtime resilience.
- MinIO bucket setup included in prod override to reduce manual setup drift.
- Dev compose frontend env duplication removed to reduce conflicting variable paths.

## Technical Requirements

- Code must follow project standards and guidelines [see wiki](https://github.com/MuneraCappin/PermitParser/wiki/Code-Standards)
- Architecture diagrams must be updated if needed [see wiki](https://github.com/MuneraCappin/PermitParser/wiki/System-Diagrams)

## Definition of Done

- [x] Code implemented and follows standards
- [x] Risk mitigation addressed
- [ ] Documentation updated
- [ ] Story tagged in git when completed
- [ ] PR reviewed and risks audited

