### PR TITLE
Fix BUG-2.2: Centralize sport image mapping in constants (Tech Debt)

### DIFF
--- a/playlocal/frontend/components/CreateGame.tsx
+++ b/playlocal/frontend/components/CreateGame.tsx
@@ -16,36 +16,7 @@ import {
 import { useCreateGame } from '@/hooks/useGames';
 import { useAuth } from '@/context/AuthContext';
 import { gamesApi, TagDto } from '@/lib/api';
-
-// Helper to get image by sport
-function getSportImage(sport: string) {
-  const images: Record<string, string> = {
-    Basketball:
-      'https://images.unsplash.com/photo-1546519638-68e109498ffc?auto=format&fit=crop&q=80&w=1080',
-    Soccer:
-      'https://images.unsplash.com/photo-1579952363873-27f3bade9f55?auto=format&fit=crop&q=80&w=1080',
-    Tennis:
-      'https://images.unsplash.com/photo-1595435934249-5df7ed86e1c0?auto=format&fit=crop&q=80&w=1080',
-    Volleyball:
-      'https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?auto=format&fit=crop&q=80&w=1080',
-    Badminton:
-      'https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?auto=format&fit=crop&q=80&w=1080',
-    Baseball: '/images/sports/baseball.jpg',
-    Hockey:
-      'https://images.unsplash.com/photo-1580748141549-71748dbe0bdc?auto=format&fit=crop&q=80&w=1080',
-    'Ultimate Frisbee': '/images/sports/ultimate-frisbee.jpg',
-    'Flag Football':
-      'https://images.unsplash.com/photo-1566577739112-5180d4bf9390?auto=format&fit=crop&q=80&w=1080',
-    Softball:
-      'https://images.unsplash.com/photo-1578432014316-48b448d79d57?auto=format&fit=crop&q=80&w=1080',
-    Pickleball:
-      'https://images.unsplash.com/photo-1526888935184-a82d2a4b7e67?auto=format&fit=crop&q=80&w=1080',
-  };
-  return (
-    images[sport] ||
-    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&q=80&w=1080'
-  );
-}
+import { getSportImage } from '@/constants/sportImages';
 
 function getVisibilityLabel(visibility: string): string {
   if (visibility === 'public') return 'Public';

--- a/playlocal/frontend/components/GameDiscovery.tsx
+++ b/playlocal/frontend/components/GameDiscovery.tsx
@@ -16,37 +16,8 @@ import {
 } from 'lucide-react';
 import { useGames } from '@/hooks/useGames';
 import { GameResponse } from '@/lib/api';
+import { getSportImage } from '@/constants/sportImages';
 import MapView from './MapView';
-
-// Helper to get image by sport (US 2.2)
-function getSportImage(sport: string) {
-  const images: Record<string, string> = {
-    Basketball:
-      'https://images.unsplash.com/photo-1546519638-68e109498ffc?auto=format&fit=crop&q=80&w=1080',
-    Soccer:
-      'https://images.unsplash.com/photo-1579952363873-27f3bade9f55?auto=format&fit=crop&q=80&w=1080',
-    Tennis:
-      'https://images.unsplash.com/photo-1595435934249-5df7ed86e1c0?auto=format&fit=crop&q=80&w=1080',
-    Volleyball:
-      'https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?auto=format&fit=crop&q=80&w=1080',
-    Badminton:
-      'https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?auto=format&fit=crop&q=80&w=1080',
-    Baseball: '/images/sports/baseball.jpg',
-    Hockey:
-      'https://images.unsplash.com/photo-1580748141549-71748dbe0bdc?auto=format&fit=crop&q=80&w=1080',
-    'Ultimate Frisbee': '/images/sports/ultimate-frisbee.jpg',
-    'Flag Football':
-      'https://images.unsplash.com/photo-1566577739112-5180d4bf9390?auto=format&fit=crop&q=80&w=1080',
-    Softball:
-      'https://images.unsplash.com/photo-1578432014316-48b448d79d57?auto=format&fit=crop&q=80&w=1080',
-    Pickleball:
-      'https://images.unsplash.com/photo-1526888935184-a82d2a4b7e67?auto=format&fit=crop&q=80&w=1080',
-  };
-  return (
-    images[sport] ||
-    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&q=80&w=1080'
-  );
-}
 
 // Transform API response to display format
 function transformApiGame(game: GameResponse) {

--- a/playlocal/frontend/components/GameRoom.tsx
+++ b/playlocal/frontend/components/GameRoom.tsx
@@ -40,36 +40,7 @@ import { ReportModal } from './ReportModal';
 import { JoinConfirmationModal } from './JoinConfirmationModal';
 import { OrganizerQualityBadge } from './OrganizerQualityBadge';
 import { PhotosPanel } from './photos/PhotosPanel';
-
-// Helper to get image by sport (US 2.2)
-function getSportImage(sport: string) {
-  const images: Record<string, string> = {
-    Basketball:
-      'https://images.unsplash.com/photo-1546519638-68e109498ffc?auto=format&fit=crop&q=80&w=1080',
-    Soccer:
-      'https://images.unsplash.com/photo-1579952363873-27f3bade9f55?auto=format&fit=crop&q=80&w=1080',
-    Tennis:
-      'https://images.unsplash.com/photo-1595435934249-5df7ed86e1c0?auto=format&fit=crop&q=80&w=1080',
-    Volleyball:
-      'https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?auto=format&fit=crop&q=80&w=1080',
-    Badminton:
-      'https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?auto=format&fit=crop&q=80&w=1080',
-    Baseball: '/images/sports/baseball.jpg',
-    Hockey:
-      'https://images.unsplash.com/photo-1580748141549-71748dbe0bdc?auto=format&fit=crop&q=80&w=1080',
-    'Ultimate Frisbee': '/images/sports/ultimate-frisbee.jpg',
-    'Flag Football':
-      'https://images.unsplash.com/photo-1566577739112-5180d4bf9390?auto=format&fit=crop&q=80&w=1080',
-    Softball:
-      'https://images.unsplash.com/photo-1578432014316-48b448d79d57?auto=format&fit=crop&q=80&w=1080',
-    Pickleball:
-      'https://images.unsplash.com/photo-1526888935184-a82d2a4b7e67?auto=format&fit=crop&q=80&w=1080',
-  };
-  return (
-    images[sport] ||
-    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&q=80&w=1080'
-  );
-}
+import { getSportImage } from '@/constants/sportImages';
 
 // Mock data for fallback when backend unavailable
 const mockGame = {

--- a/playlocal/frontend/components/sub-components/RosterHeader.tsx
+++ b/playlocal/frontend/components/sub-components/RosterHeader.tsx
@@ -1,35 +1,6 @@
 import { MapPin, Clock } from 'lucide-react';
 import { format } from 'date-fns/format';
-
-// Helper to get image by sport (US 2.2)
-function getSportImage(sport: string) {
-  const images: Record<string, string> = {
-    Basketball:
-      'https://images.unsplash.com/photo-1546519638-68e109498ffc?auto=format&fit=crop&q=80&w=1080',
-    Soccer:
-      'https://images.unsplash.com/photo-1579952363873-27f3bade9f55?auto=format&fit=crop&q=80&w=1080',
-    Tennis:
-      'https://images.unsplash.com/photo-1595435934249-5df7ed86e1c0?auto=format&fit=crop&q=80&w=1080',
-    Volleyball:
-      'https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?auto=format&fit=crop&q=80&w=1080',
-    Badminton:
-      'https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?auto=format&fit=crop&q=80&w=1080',
-    Baseball: '/images/sports/baseball.jpg',
-    Hockey:
-      'https://images.unsplash.com/photo-1580748141549-71748dbe0bdc?auto=format&fit=crop&q=80&w=1080',
-    'Ultimate Frisbee': '/images/sports/ultimate-frisbee.jpg',
-    'Flag Football':
-      'https://images.unsplash.com/photo-1566577739112-5180d4bf9390?auto=format&fit=crop&q=80&w=1080',
-    Softball:
-      'https://images.unsplash.com/photo-1578432014316-48b448d79d57?auto=format&fit=crop&q=80&w=1080',
-    Pickleball:
-      'https://images.unsplash.com/photo-1526888935184-a82d2a4b7e67?auto=format&fit=crop&q=80&w=1080',
-  };
-  return (
-    images[sport] ||
-    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&q=80&w=1080'
-  );
-}
+import { getSportImage } from '@/constants/sportImages';
 
 type RosterHeaderProps = {
   game: {

--- a/playlocal/frontend/constants/sportImages.ts
+++ b/playlocal/frontend/constants/sportImages.ts
@@ -1,0 +1,44 @@
+/**
+ * Centralized sport → image URL mapping (US-2.2).
+ * Single source of truth for sport card images across GameDiscovery, GameRoom,
+ * CreateGame, RosterHeader, and other components.
+ *
+ * To add a new sport: add an entry to SPORT_IMAGES and optionally update
+ * DEFAULT_SPORT_IMAGE for the fallback.
+ */
+
+/** Default image URL when sport is not found in the mapping */
+export const DEFAULT_SPORT_IMAGE =
+  'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&q=80&w=1080';
+
+/** Sport name → image URL mapping */
+export const SPORT_IMAGES: Record<string, string> = {
+  Basketball:
+    'https://images.unsplash.com/photo-1546519638-68e109498ffc?auto=format&fit=crop&q=80&w=1080',
+  Soccer:
+    'https://images.unsplash.com/photo-1579952363873-27f3bade9f55?auto=format&fit=crop&q=80&w=1080',
+  Tennis:
+    'https://images.unsplash.com/photo-1595435934249-5df7ed86e1c0?auto=format&fit=crop&q=80&w=1080',
+  Volleyball:
+    'https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?auto=format&fit=crop&q=80&w=1080',
+  Badminton:
+    'https://images.unsplash.com/photo-1599391398131-cd12dfc6c24e?auto=format&fit=crop&q=80&w=1080',
+  Baseball: '/images/sports/baseball.jpg',
+  Hockey:
+    'https://images.unsplash.com/photo-1580748141549-71748dbe0bdc?auto=format&fit=crop&q=80&w=1080',
+  'Ultimate Frisbee': '/images/sports/ultimate-frisbee.jpg',
+  'Flag Football':
+    'https://images.unsplash.com/photo-1566577739112-5180d4bf9390?auto=format&fit=crop&q=80&w=1080',
+  Softball:
+    'https://images.unsplash.com/photo-1578432014316-48b448d79d57?auto=format&fit=crop&q=80&w=1080',
+  Pickleball:
+    'https://images.unsplash.com/photo-1526888935184-a82d2a4b7e67?auto=format&fit=crop&q=80&w=1080',
+};
+
+/**
+ * Returns the image URL for a given sport name.
+ * Falls back to DEFAULT_SPORT_IMAGE when the sport is not in the mapping.
+ */
+export function getSportImage(sport: string): string {
+  return SPORT_IMAGES[sport] ?? DEFAULT_SPORT_IMAGE;
+}

--- a/playlocal/frontend/package-lock.json
+++ b/playlocal/frontend/package-lock.json
@@ -5978,7 +5978,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5987,7 +5987,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7377,7 +7377,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -14278,21 +14278,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
-      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }


### PR DESCRIPTION
---
name: 'Pull Request'
title: 'PR-BUG-2.2: Centralize sport image mapping (constants file)'
labels: 
assignees: '@elshito'
milestone: 'Iteration 11&12'
---

# Pull Request

## Description

Centralize sport image mapping in a dedicated constants file instead of hardcoding URLs inside `GameDiscovery.tsx` and other components. This improves maintainability and provides a single source of truth for sport → image URL mapping (US-2.2).

**Changes:**
- Added `playlocal/frontend/constants/sportImages.ts` with `SPORT_IMAGES`, `DEFAULT_SPORT_IMAGE`, and `getSportImage(sport)`.
- Removed inline `getSportImage()` from `GameDiscovery.tsx`, `GameRoom.tsx`, `CreateGame.tsx`, and `RosterHeader.tsx`; all now import from `@/constants/sportImages`.

Closes #124

## Type of Change

- [x] Bug fix
- [ ] New feature (User Story)
- [ ] Task implementation
- [ ] Documentation update
- [x] Code refactoring
- [ ] Unit tests
- [ ] Other (please describe)

## Related Issues

- Fixes: #124
- Related to: US-2.2 (Game Discovery / sport cards images)

## All relevant files to this PR

- `playlocal/frontend/constants/sportImages.ts` (new)
- `playlocal/frontend/components/GameDiscovery.tsx`
- `playlocal/frontend/components/GameRoom.tsx`
- `playlocal/frontend/components/CreateGame.tsx`
- `playlocal/frontend/components/sub-components/RosterHeader.tsx`

## Requirements Reference [Mandatory for User Stories]

**Requirement Reference:** US-2.2 (Game Discovery / sport cards images)

**Justification:** Sport image mappings are now stored in a single constants module (`constants/sportImages.ts`), so the UI references one source of truth. Adding or changing sport images is done in one place, reducing duplication and maintenance risk.

## Risk Mitigation [Mandatory for User Stories]

**Associated Risks:** Low — code-level tech debt; no new feature behavior.

**Mitigation Strategy:** Fix now.

**Details:** All four consumers (GameDiscovery, GameRoom, CreateGame, RosterHeader) were updated to use the shared module. Build and existing RosterHeader tests pass; fallback for unknown sports unchanged (`DEFAULT_SPORT_IMAGE`).

## Technical Requirements

- Code follows project standards and guidelines.
- No architecture changes; frontend-only constants refactor.

## Unit Tests

**Unit Test Status:** Completed (existing tests)

**Test Documentation:** N/A

- [x] Unit tests written (existing; no new tests required for refactor)
- [x] Code coverage maintained (RosterHeader tests cover `getSportImage` usage)
- [ ] Unit tests documented
- [x] All tests passing (RosterHeader suite; full suite run separately)

## Related Links

**Architecture Diagrams:** N/A (no architectural change)

## Customer Signoff

- [ ] Requirements reviewed with customer/stakeholder
- [ ] Acceptance criteria approved
- [ ] Customer signoff received (add customer-approved label when complete)

## Definition of Done

- [x] Code implemented and follows standards
- [x] Risk mitigation addressed
- [ ] Documentation updated (inline JSDoc in `sportImages.ts`)
- [ ] Story tagged in git when completed
- [ ] PR reviewed and risks audited

## Additional Notes

- Default/unknown sport still uses the same Unsplash fallback URL.
- Future backend-driven sport images could replace or supplement this constants file without changing component APIs (`getSportImage(sport)` signature unchanged).
