### PR TITLE
Fix BUG-1.4: Limit report rate to 2 per hour to prevent spam/abuse

### DIFF
--- a/playlocal/backend/src/main/java/com/backend/playlocal/config/RateLimitConfig.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/config/RateLimitConfig.java
@@ -33,7 +33,7 @@ public class RateLimitConfig {
     }
 
     public static class ReportLimit {
-        private int maxPerHour = 10;
+        private int maxPerHour = 2;
 
         public int getMaxPerHour() {
             return maxPerHour;

--- a/playlocal/backend/src/main/java/com/backend/playlocal/service/ReportService.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/service/ReportService.java
@@ -54,7 +54,7 @@ public class ReportService {
         User reporter = userRepository.findActiveById(reporterId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
-        // Rate limit check (10 reports per hour)
+        // Rate limit check (2 reports per hour to avoid spam/abuse)
         int recentReports = reportRepository.countRecentReportsByUser(
                 reporterId, Instant.now().minus(1, ChronoUnit.HOURS));
         if (recentReports >= rateLimitConfig.getReport().getMaxPerHour()) {

--- a/playlocal/backend/src/main/resources/application.yml
+++ b/playlocal/backend/src/main/resources/application.yml
@@ -46,7 +46,7 @@ rate-limit:
     max-attempts: 5
     window-minutes: 15
   report:
-    max-per-hour: 10
+    max-per-hour: 2
   general:
     requests-per-minute: 60
 

--- a/playlocal/backend/src/test/java/com/backend/playlocal/unit/ReportServiceTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/unit/ReportServiceTest.java
@@ -101,7 +101,7 @@ class ReportServiceTest {
                                 .build();
 
                 when(rateLimitConfig.getReport()).thenReturn(reportLimit);
-                when(reportLimit.getMaxPerHour()).thenReturn(10);
+                when(reportLimit.getMaxPerHour()).thenReturn(2);
         }
 
         @Test
@@ -248,11 +248,11 @@ class ReportServiceTest {
         }
 
         @Test
-        @DisplayName("US-1.4: createReport rate limit exceeded throws exception")
+        @DisplayName("US-1.4: createReport rate limit exceeded throws exception (max 2 per hour)")
         void createReport_RateLimitExceeded_ThrowsException() {
-                // Given
+                // Given: user already has 2 reports in the last hour (limit is 2)
                 when(userRepository.findActiveById(reporterId)).thenReturn(Optional.of(reporter));
-                when(reportRepository.countRecentReportsByUser(eq(reporterId), any(Instant.class))).thenReturn(10);
+                when(reportRepository.countRecentReportsByUser(eq(reporterId), any(Instant.class))).thenReturn(2);
 
                 ReportDto.CreateRequest request = ReportDto.CreateRequest.builder()
                                 .reportedUserId(reportedUserId.toString())


### PR DESCRIPTION
---
name: 'Pull Request #121 '
title: 'PR-121: Fix report rate limit to 2 per hour (BUG-1.4)'
labels: bug
assignees: ''
milestone: 'Iteration 12'
---

# Pull Request

## Description

Reduces the reporting rate limit from **10** to **2 reports per hour** to prevent report spam and abuse. Users were able to submit up to 10 reports per hour against the same or different users/games; the backend now enforces a maximum of 2 reports per hour per user.

Closes #121

## Type of Change

- [x] Bug fix
- [ ] New feature (User Story)
- [ ] Task implementation
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Unit tests
- [ ] Other (please describe)

## Related Issues

- Fixes: #121 (BUG-1.4: Reporting Limit Rate)

## All relevant files to this PR

- `playlocal/backend/src/main/java/com/backend/playlocal/config/RateLimitConfig.java` — default `maxPerHour` for reports changed from 10 to 2
- `playlocal/backend/src/main/resources/application.yml` — `rate-limit.report.max-per-hour` set from 10 to 2
- `playlocal/backend/src/main/java/com/backend/playlocal/service/ReportService.java` — comment updated to reflect 2 reports/hour limit
- `playlocal/backend/src/test/java/com/backend/playlocal/unit/ReportServiceTest.java` — mock and rate-limit test updated for new limit (2 per hour)

## Requirements Reference [Mandatory for User Stories]

N/A — bug fix, not a User Story.

## Risk Mitigation [Mandatory for User Stories]

N/A — bug fix. Risk of report spam/abuse is mitigated by enforcing the 2/hour limit.

## Technical Requirements

- Code follows existing project standards and backend patterns.
- No architecture changes; rate limit is configuration-driven and already integrated in `ReportService`.

## Unit Tests

**Unit Test Status:** Completed

- [x] Unit tests updated (`ReportServiceTest`: rate limit test and mock `getMaxPerHour()` set to 2)
- [x] Existing coverage maintained for report creation and rate limiting
- [ ] Unit tests documented (N/A if not required by project)
- [x] All tests passing (run `./mvnw test -Dtest=ReportServiceTest` in `playlocal/backend`)

## Related Links

- Issue: [#121 – BUG-1.4: Reporting Limit Rate](https://github.com/TeamCappin/PlayLocal/issues/121)
- Branch: [BUG-1.4](https://github.com/TeamCappin/PlayLocal/tree/BUG-1.4)

## Customer Signoff

- [ ] Requirements reviewed with customer/stakeholder
- [ ] Acceptance criteria approved
- [ ] Customer signoff received (add customer-approved label when complete)

## Definition of Done

- [x] Code implemented and follows standards
- [x] Risk mitigation addressed (spam/abuse limited to 2 reports/hour)
- [ ] Documentation updated (if required)
- [ ] Story tagged in git when completed
- [ ] PR reviewed and risks audited

## Additional Notes

- Frontend already handles HTTP 429 (rate limit) with: *"You have submitted too many reports. Please try again later."* No frontend changes required.
- Limit remains configurable via `rate-limit.report.max-per-hour` in `application.yml` for environment-specific tuning.
