### PR TITLE
Us 2.8

### DIFF
--- a/playlocal/backend/src/main/java/com/backend/playlocal/controller/NotificationController.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/controller/NotificationController.java
@@ -44,8 +44,9 @@ public class NotificationController {
      * Mark notification as read.
      */
     @PostMapping("/{notificationId}/read")
-    public ResponseEntity<Void> markAsRead(@PathVariable UUID notificationId) {
-        notificationService.markAsRead(notificationId);
+    public ResponseEntity<Void> markAsRead(@PathVariable UUID notificationId, Authentication authentication) {
+        UUID userId = UUID.fromString(authentication.getName());
+        notificationService.markAsRead(userId, notificationId);
         return ResponseEntity.noContent().build();
     }
 

--- a/playlocal/backend/src/main/java/com/backend/playlocal/repository/GameRepository.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/repository/GameRepository.java
@@ -129,6 +129,14 @@ public interface GameRepository extends JpaRepository<Game, UUID> {
 
     @Query("SELECT g FROM Game g WHERE g.status IN ('SCHEDULED', 'IN_PROGRESS') AND g.endTime IS NOT NULL AND g.endTime <= :time")
     List<Game> findGamesToComplete(Instant time);
+
+    @Query("SELECT g FROM Game g " +
+            "LEFT JOIN FETCH g.sport " +
+            "LEFT JOIN FETCH g.createdBy " +
+            "LEFT JOIN FETCH g.location " +
+            "WHERE g.status = 'SCHEDULED' AND g.startTime > :windowStart AND g.startTime <= :windowEnd")
+    List<Game> findGamesStartingSoon(Instant windowStart, Instant windowEnd);
+
     @Query("SELECT g FROM Game g " +
             "LEFT JOIN FETCH g.sport " +
             "LEFT JOIN FETCH g.createdBy " +

--- a/playlocal/backend/src/main/java/com/backend/playlocal/repository/NotificationRepository.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/repository/NotificationRepository.java
@@ -7,20 +7,25 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 
-    @Query("SELECT n FROM Notification n WHERE n.user.userId = :userId AND n.channel = 'IN_APP' ORDER BY n.scheduledFor DESC")
+    @Query("SELECT n FROM Notification n WHERE n.user.userId = :userId AND n.channel = 'IN_APP' AND n.status IN ('SENT', 'READ') ORDER BY n.scheduledFor DESC")
     List<Notification> findUserNotifications(UUID userId);
 
-    @Query("SELECT n FROM Notification n WHERE n.user.userId = :userId AND n.status <> 'READ' AND n.channel = 'IN_APP' ORDER BY n.scheduledFor DESC")
+    @Query("SELECT n FROM Notification n WHERE n.user.userId = :userId AND n.status = 'SENT' AND n.channel = 'IN_APP' ORDER BY n.scheduledFor DESC")
     List<Notification> findUnreadNotifications(UUID userId);
 
     @Query("SELECT n FROM Notification n WHERE n.status = 'PENDING' AND n.scheduledFor <= :now")
     List<Notification> findPendingToSend(Instant now);
 
-    @Query("SELECT COUNT(n) FROM Notification n WHERE n.user.userId = :userId AND n.status <> 'READ' AND n.channel = 'IN_APP'")
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.user.userId = :userId AND n.status = 'SENT' AND n.channel = 'IN_APP'")
     int countUnread(UUID userId);
+
+    Optional<Notification> findByNotificationIdAndUser_UserId(UUID notificationId, UUID userId);
+
+    boolean existsByProviderMessageId(String providerMessageId);
 }

--- a/playlocal/backend/src/main/java/com/backend/playlocal/scheduler/GameLifecycleScheduler.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/scheduler/GameLifecycleScheduler.java
@@ -1,21 +1,37 @@
 package com.backend.playlocal.scheduler;
 
 import com.backend.playlocal.model.entity.Game;
+import com.backend.playlocal.model.entity.GameParticipation;
+import com.backend.playlocal.repository.GameParticipationRepository;
 import com.backend.playlocal.repository.GameRepository;
+import com.backend.playlocal.service.GameService;
+import com.backend.playlocal.service.NotificationService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 @Component
 public class GameLifecycleScheduler {
 
     private final GameRepository gameRepository;
+    private final GameParticipationRepository participationRepository;
+    private final GameService gameService;
+    private final NotificationService notificationService;
 
-    public GameLifecycleScheduler(GameRepository gameRepository) {
+    public GameLifecycleScheduler(
+            GameRepository gameRepository,
+            GameParticipationRepository participationRepository,
+            GameService gameService,
+            NotificationService notificationService) {
         this.gameRepository = gameRepository;
+        this.participationRepository = participationRepository;
+        this.gameService = gameService;
+        this.notificationService = notificationService;
     }
 
     @Scheduled(fixedDelayString = "${game.lifecycle.update-interval-ms:60000}")
@@ -27,9 +43,44 @@ public class GameLifecycleScheduler {
         }
 
         for (Game game : gamesToComplete) {
-            game.setStatus(Game.GameStatus.COMPLETED);
+            gameService.completeGameByScheduler(game.getGameId());
         }
+    }
 
-        gameRepository.saveAll(gamesToComplete);
+    @Scheduled(fixedDelayString = "${notifications.starting-soon.interval-ms:60000}")
+    @Transactional
+    public void sendStartingSoonNotifications() {
+        Instant now = Instant.now();
+        Instant windowEnd = now.plusSeconds(2 * 60 * 60); // 2h
+        List<Game> games = gameRepository.findGamesStartingSoon(now, windowEnd);
+        for (Game game : games) {
+            notifyParticipantsGameStartingSoon(game);
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${notifications.pending.interval-ms:60000}")
+    @Transactional
+    public void processPendingNotifications() {
+        notificationService.processPendingNotifications();
+    }
+
+    private void notifyParticipantsGameStartingSoon(Game game) {
+        List<GameParticipation> confirmed = participationRepository.findConfirmedByGame(game.getGameId());
+        List<GameParticipation> waitlisted = participationRepository.findWaitlistedByGame(game.getGameId());
+        UUID organizerId = game.getCreatedBy().getUserId();
+        Set<UUID> notified = new java.util.HashSet<>();
+
+        for (GameParticipation p : confirmed) {
+            UUID userId = p.getUser().getUserId();
+            if (!userId.equals(organizerId) && notified.add(userId)) {
+                notificationService.notifyGameStartingSoon(game, userId);
+            }
+        }
+        for (GameParticipation p : waitlisted) {
+            UUID userId = p.getUser().getUserId();
+            if (!userId.equals(organizerId) && notified.add(userId)) {
+                notificationService.notifyGameStartingSoon(game, userId);
+            }
+        }
     }
 }

--- a/playlocal/backend/src/main/java/com/backend/playlocal/scheduler/GameLifecycleScheduler.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/scheduler/GameLifecycleScheduler.java
@@ -51,7 +51,7 @@ public class GameLifecycleScheduler {
     @Transactional
     public void sendStartingSoonNotifications() {
         Instant now = Instant.now();
-        Instant windowEnd = now.plusSeconds(2 * 60 * 60); // 2h
+        Instant windowEnd = now.plusSeconds(2L * 60 * 60); // 2h
         List<Game> games = gameRepository.findGamesStartingSoon(now, windowEnd);
         for (Game game : games) {
             notifyParticipantsGameStartingSoon(game);

--- a/playlocal/backend/src/main/java/com/backend/playlocal/service/GameService.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/service/GameService.java
@@ -10,14 +10,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.backend.playlocal.service.OrganizerQualityService;
-
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneOffset;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -435,6 +432,9 @@ public class GameService {
                                 promoted.setJoinStatus(GameParticipation.JoinStatus.CONFIRMED);
                                 promoted.setWaitlistPosition(null);
                                 participationRepository.save(promoted);
+                                if (notificationService != null) {
+                                        notificationService.notifyWaitlistPromoted(participation.getGame(), promoted.getUser().getUserId());
+                                }
 
                                 // Decrement remaining waitlist positions
                                 participationRepository.decrementWaitlistPositionsAfter(gameId, 1);
@@ -504,6 +504,9 @@ public class GameService {
                                         promoted.setJoinStatus(GameParticipation.JoinStatus.CONFIRMED);
                                         promoted.setWaitlistPosition(null);
                                         participationRepository.save(promoted);
+                                        if (notificationService != null) {
+                                                notificationService.notifyWaitlistPromoted(game, promoted.getUser().getUserId());
+                                        }
                                         participationRepository.decrementWaitlistPositionsAfter(gameId, 1);
                                 }
                         } else if (oldWaitlistPosition > 0) {
@@ -590,8 +593,9 @@ public class GameService {
                 payload.put("message", String.format("The game \"%s\" has been cancelled by the organizer.",
                                 game.getTitle()));
                 payload.put("gameId", game.getGameId().toString());
+                payload.put("gameTitle", game.getTitle());
                 payload.put("link", "/discover");
-                notificationService.createInAppNotification(userId, "GAME_CANCELLED", payload);
+                notificationService.createInAppNotification(userId, NotificationService.TYPE_GAME_CANCELLED, payload);
         }
 
         /**
@@ -751,7 +755,6 @@ public class GameService {
                 game.setCancelledAt(Instant.now());
                 game = gameRepository.save(game);
 
-                notifyCancellation(game);
                 // US-6.1: Recalculate OQS for the organizer after game cancellation
                 oqsService.onGameCancelled(gameId);
 
@@ -770,15 +773,18 @@ public class GameService {
                                 .orElseThrow(() -> new ResourceNotFoundException("Game not found"));
 
                 assertOrganizer(game, userId);
-
-                if (game.getStatus() == Game.GameStatus.CANCELLED || game.getStatus() == Game.GameStatus.ARCHIVED) {
-                        throw new IllegalStateException(
-                                        "Cannot complete a game that is " + game.getStatus().name().toLowerCase());
-                }
-
-                game.setStatus(Game.GameStatus.COMPLETED);
-                game = gameRepository.save(game);
+                game = completeGameInternal(game);
                 return mapToGameResponse(game, userId);
+        }
+
+        /**
+         * Complete overdue game via scheduler and trigger organizer attendance reminder.
+         */
+        @Transactional
+        public Game completeGameByScheduler(UUID gameId) {
+                Game game = gameRepository.findById(gameId)
+                                .orElseThrow(() -> new ResourceNotFoundException("Game not found"));
+                return completeGameInternal(game);
         }
 
         /**
@@ -1057,38 +1063,20 @@ public class GameService {
                 }
         }
 
-        private void notifyCancellation(Game game) {
-                List<GameParticipation> confirmed = Optional
-                                .ofNullable(participationRepository.findConfirmedByGame(game.getGameId()))
-                                .orElseGet(List::of);
-                List<GameParticipation> waitlisted = Optional
-                                .ofNullable(participationRepository.findWaitlistedByGame(game.getGameId()))
-                                .orElseGet(List::of);
-                Set<UUID> notified = new HashSet<>();
-
-                Map<String, Object> payload = Map.of(
-                                "gameId", game.getGameId().toString(),
-                                "gameTitle", game.getTitle(),
-                                "status", game.getStatus().name(),
-                                "message", "Game cancelled: " + game.getTitle());
-
-                for (GameParticipation participation : confirmed) {
-                        addCancellationNotification(participation, game, payload, notified);
+        private Game completeGameInternal(Game game) {
+                if (game.getStatus() == Game.GameStatus.CANCELLED || game.getStatus() == Game.GameStatus.ARCHIVED) {
+                        throw new IllegalStateException(
+                                        "Cannot complete a game that is " + game.getStatus().name().toLowerCase());
                 }
-                for (GameParticipation participation : waitlisted) {
-                        addCancellationNotification(participation, game, payload, notified);
+                if (game.getStatus() == Game.GameStatus.COMPLETED) {
+                        return game;
                 }
-        }
 
-        private void addCancellationNotification(GameParticipation participation, Game game,
-                        Map<String, Object> payload, Set<UUID> notified) {
-                UUID userId = participation.getUser().getUserId();
-                if (userId.equals(game.getCreatedBy().getUserId()) || notified.contains(userId)) {
-                        return;
-                }
+                game.setStatus(Game.GameStatus.COMPLETED);
+                Game saved = gameRepository.save(game);
                 if (notificationService != null) {
-                        notificationService.createInAppNotification(userId, "game_cancelled", payload);
-                        notified.add(userId);
+                        notificationService.notifyAttendanceConfirmationNeeded(saved);
                 }
+                return saved;
         }
 }

--- a/playlocal/backend/src/main/java/com/backend/playlocal/service/NotificationService.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/service/NotificationService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -26,6 +27,10 @@ import java.util.stream.Collectors;
 public class NotificationService {
 
     private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+    public static final String TYPE_GAME_CANCELLED = "GAME_CANCELLED";
+    public static final String TYPE_WAITLIST_PROMOTED = "WAITLIST_PROMOTED";
+    public static final String TYPE_GAME_STARTING_SOON = "GAME_STARTING_SOON";
+    public static final String TYPE_ATTENDANCE_PROMPT = "ATTENDANCE_PROMPT";
 
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
@@ -44,6 +49,18 @@ public class NotificationService {
      */
     @Transactional
     public Notification createInAppNotification(UUID userId, String type, Map<String, Object> payload) {
+        return createInAppNotification(userId, type, payload, null);
+    }
+
+    /**
+     * Create in-app notification for a user with optional idempotency key.
+     */
+    @Transactional
+    public Notification createInAppNotification(UUID userId, String type, Map<String, Object> payload, String idempotencyKey) {
+        if (idempotencyKey != null && notificationRepository.existsByProviderMessageId(idempotencyKey)) {
+            return null;
+        }
+
         User user = userRepository.findActiveById(userId).orElse(null);
         if (user == null) {
             log.warn("Attempted to notify non-existent user: {}", userId);
@@ -65,6 +82,7 @@ public class NotificationService {
                 .scheduledFor(Instant.now())
                 .status(Notification.NotificationStatus.SENT)
                 .sentAt(Instant.now())
+                .providerMessageId(idempotencyKey)
                 .build();
 
         return notificationRepository.save(notification);
@@ -77,11 +95,16 @@ public class NotificationService {
     @Transactional
     public Notification scheduleAttendanceReminder(Game game, Instant scheduledFor) {
         User organizer = game.getCreatedBy();
+        String inAppKey = buildIdempotencyKey(TYPE_ATTENDANCE_PROMPT, game.getGameId(), organizer.getUserId());
+        if (notificationRepository.existsByProviderMessageId(inAppKey)) {
+            return null;
+        }
 
         Map<String, Object> payload = Map.of(
                 "gameId", game.getGameId().toString(),
                 "gameTitle", game.getTitle(),
-                "message", "Please confirm attendance for your game: " + game.getTitle());
+                "message", "Please confirm attendance for your game: " + game.getTitle(),
+                "link", "/games/" + game.getGameId());
 
         String payloadJson = null;
         try {
@@ -94,19 +117,22 @@ public class NotificationService {
         Notification inAppNotification = Notification.builder()
                 .user(organizer)
                 .channel(Notification.NotificationChannel.IN_APP)
-                .notifType("attendance_prompt")
+                .notifType(TYPE_ATTENDANCE_PROMPT)
                 .payloadJson(payloadJson)
                 .scheduledFor(scheduledFor)
                 .status(Notification.NotificationStatus.PENDING)
+                .providerMessageId(inAppKey)
                 .build();
 
         Notification emailNotification = Notification.builder()
                 .user(organizer)
                 .channel(Notification.NotificationChannel.EMAIL)
-                .notifType("attendance_prompt")
+                .notifType(TYPE_ATTENDANCE_PROMPT)
                 .payloadJson(payloadJson)
                 .scheduledFor(scheduledFor)
                 .status(Notification.NotificationStatus.PENDING)
+                .providerMessageId(
+                        "EMAIL:" + buildIdempotencyKey(TYPE_ATTENDANCE_PROMPT, game.getGameId(), organizer.getUserId()))
                 .build();
 
         notificationRepository.save(inAppNotification);
@@ -135,11 +161,12 @@ public class NotificationService {
      * Mark notification as read.
      */
     @Transactional
-    public void markAsRead(UUID notificationId) {
-        notificationRepository.findById(notificationId).ifPresent(n -> {
+    public boolean markAsRead(UUID userId, UUID notificationId) {
+        return notificationRepository.findByNotificationIdAndUser_UserId(notificationId, userId).map(n -> {
             n.setStatus(Notification.NotificationStatus.READ);
             notificationRepository.save(n);
-        });
+            return true;
+        }).orElse(false);
     }
 
     /**
@@ -171,6 +198,47 @@ public class NotificationService {
             notification.setSentAt(Instant.now());
             notificationRepository.save(notification);
         }
+    }
+
+    @Transactional
+    public Notification notifyWaitlistPromoted(Game game, UUID userId) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("title", "Spot confirmed");
+        payload.put("message", String.format("You were promoted from waitlist to confirmed for \"%s\".", game.getTitle()));
+        payload.put("gameId", game.getGameId().toString());
+        payload.put("gameTitle", game.getTitle());
+        payload.put("link", "/games/" + game.getGameId());
+        String key = buildIdempotencyKey(TYPE_WAITLIST_PROMOTED, game.getGameId(), userId);
+        return createInAppNotification(userId, TYPE_WAITLIST_PROMOTED, payload, key);
+    }
+
+    @Transactional
+    public Notification notifyGameStartingSoon(Game game, UUID userId) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("title", "Game starting soon");
+        payload.put("message", String.format("\"%s\" starts soon. Get ready.", game.getTitle()));
+        payload.put("gameId", game.getGameId().toString());
+        payload.put("gameTitle", game.getTitle());
+        payload.put("link", "/games/" + game.getGameId());
+        String key = buildIdempotencyKey(TYPE_GAME_STARTING_SOON, game.getGameId(), userId);
+        return createInAppNotification(userId, TYPE_GAME_STARTING_SOON, payload, key);
+    }
+
+    @Transactional
+    public Notification notifyAttendanceConfirmationNeeded(Game game) {
+        UUID organizerId = game.getCreatedBy().getUserId();
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("title", "Attendance confirmation needed");
+        payload.put("message", String.format("Please confirm attendance for \"%s\".", game.getTitle()));
+        payload.put("gameId", game.getGameId().toString());
+        payload.put("gameTitle", game.getTitle());
+        payload.put("link", "/games/" + game.getGameId());
+        String key = buildIdempotencyKey(TYPE_ATTENDANCE_PROMPT, game.getGameId(), organizerId);
+        return createInAppNotification(organizerId, TYPE_ATTENDANCE_PROMPT, payload, key);
+    }
+
+    private String buildIdempotencyKey(String type, UUID gameId, UUID userId) {
+        return String.format("IN_APP:%s:%s:%s", type, gameId, userId);
     }
 
     private NotificationDto mapToDto(Notification n) {

--- a/playlocal/backend/src/test/java/com/backend/playlocal/controller/NotificationControllerTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/controller/NotificationControllerTest.java
@@ -1,0 +1,72 @@
+package com.backend.playlocal.controller;
+
+import com.backend.playlocal.service.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationControllerTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private Authentication authentication;
+
+    private NotificationController controller;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        controller = new NotificationController(notificationService);
+        userId = UUID.randomUUID();
+        when(authentication.getName()).thenReturn(userId.toString());
+    }
+
+    @Test
+    void markAsRead_UsesAuthenticatedUserForOwnershipGuard() {
+        UUID notificationId = UUID.randomUUID();
+
+        ResponseEntity<Void> response = controller.markAsRead(notificationId, authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+        verify(notificationService).markAsRead(userId, notificationId);
+    }
+
+    @Test
+    void getUnreadCount_ReturnsPayloadFromService() {
+        when(notificationService.getUnreadCount(userId)).thenReturn(3);
+
+        ResponseEntity<Map<String, Integer>> response = controller.getUnreadCount(authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("count", 3);
+        verify(notificationService).getUnreadCount(userId);
+    }
+
+    @Test
+    void getNotifications_DelegatesToService() {
+        List<NotificationService.NotificationDto> notifications = List.of(
+                new NotificationService.NotificationDto("n1", "GAME_CANCELLED", "{}", "SENT", null, null));
+        when(notificationService.getUserNotifications(userId)).thenReturn(notifications);
+
+        ResponseEntity<List<NotificationService.NotificationDto>> response = controller.getNotifications(authentication);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).hasSize(1);
+        verify(notificationService).getUserNotifications(userId);
+    }
+}

--- a/playlocal/backend/src/test/java/com/backend/playlocal/scheduler/GameLifecycleSchedulerTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/scheduler/GameLifecycleSchedulerTest.java
@@ -1,20 +1,26 @@
 package com.backend.playlocal.scheduler;
 
 import com.backend.playlocal.model.entity.Game;
+import com.backend.playlocal.model.entity.GameParticipation;
+import com.backend.playlocal.model.entity.User;
+import com.backend.playlocal.repository.GameParticipationRepository;
 import com.backend.playlocal.repository.GameRepository;
+import com.backend.playlocal.service.GameService;
+import com.backend.playlocal.service.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,39 +30,105 @@ class GameLifecycleSchedulerTest {
     @Mock
     private GameRepository gameRepository;
 
+    @Mock
+    private GameParticipationRepository participationRepository;
+
+    @Mock
+    private GameService gameService;
+
+    @Mock
+    private NotificationService notificationService;
+
     @InjectMocks
     private GameLifecycleScheduler scheduler;
 
-    @Test
-    void completeGamesPastEndTime_marksCompletedAndSaves() {
-        Game scheduled = Game.builder()
+    private Game game;
+    private User organizer;
+    private User confirmedUser;
+    private User waitlistedUser;
+
+    @BeforeEach
+    void setUp() {
+        organizer = User.builder().userId(UUID.randomUUID()).build();
+        confirmedUser = User.builder().userId(UUID.randomUUID()).build();
+        waitlistedUser = User.builder().userId(UUID.randomUUID()).build();
+        game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .createdBy(organizer)
                 .status(Game.GameStatus.SCHEDULED)
-                .endTime(Instant.now().minusSeconds(60))
+                .title("Morning Basketball")
+                .startTime(Instant.now().plusSeconds(1800))
                 .build();
-        Game inProgress = Game.builder()
-                .status(Game.GameStatus.IN_PROGRESS)
-                .endTime(Instant.now().minusSeconds(120))
-                .build();
-
-        when(gameRepository.findGamesToComplete(any(Instant.class)))
-                .thenReturn(List.of(scheduled, inProgress));
-
-        scheduler.completeGamesPastEndTime();
-
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<Game>> gamesCaptor = ArgumentCaptor.forClass(List.class);
-        verify(gameRepository).saveAll(gamesCaptor.capture());
-        List<Game> saved = gamesCaptor.getValue();
-        assertThat(saved).hasSize(2);
-        assertThat(saved).allMatch(game -> game.getStatus() == Game.GameStatus.COMPLETED);
     }
 
     @Test
-    void completeGamesPastEndTime_noGames_doesNotSave() {
-        when(gameRepository.findGamesToComplete(any(Instant.class))).thenReturn(List.of());
+    void completeGamesPastEndTime_UsesGameServiceCompletionFlow() {
+        when(gameRepository.findGamesToComplete(any())).thenReturn(List.of(game));
 
         scheduler.completeGamesPastEndTime();
 
-        verify(gameRepository, never()).saveAll(any());
+        verify(gameService).completeGameByScheduler(game.getGameId());
+    }
+
+    @Test
+    void completeGamesPastEndTime_WhenNoGames_DoesNothing() {
+        when(gameRepository.findGamesToComplete(any())).thenReturn(List.of());
+
+        scheduler.completeGamesPastEndTime();
+
+        verify(gameService, never()).completeGameByScheduler(any());
+    }
+
+    @Test
+    void sendStartingSoonNotifications_NotifiesUniqueParticipantsExcludingOrganizer() {
+        GameParticipation organizerParticipation = GameParticipation.builder()
+                .game(game)
+                .user(organizer)
+                .joinStatus(GameParticipation.JoinStatus.CONFIRMED)
+                .build();
+        GameParticipation confirmedParticipation = GameParticipation.builder()
+                .game(game)
+                .user(confirmedUser)
+                .joinStatus(GameParticipation.JoinStatus.CONFIRMED)
+                .build();
+        GameParticipation duplicateWaitlisted = GameParticipation.builder()
+                .game(game)
+                .user(confirmedUser)
+                .joinStatus(GameParticipation.JoinStatus.WAITLISTED)
+                .waitlistPosition(2)
+                .build();
+        GameParticipation waitlistedParticipation = GameParticipation.builder()
+                .game(game)
+                .user(waitlistedUser)
+                .joinStatus(GameParticipation.JoinStatus.WAITLISTED)
+                .waitlistPosition(1)
+                .build();
+
+        when(gameRepository.findGamesStartingSoon(any(), any())).thenReturn(List.of(game));
+        when(participationRepository.findConfirmedByGame(game.getGameId()))
+                .thenReturn(List.of(organizerParticipation, confirmedParticipation));
+        when(participationRepository.findWaitlistedByGame(game.getGameId()))
+                .thenReturn(List.of(waitlistedParticipation, duplicateWaitlisted));
+
+        scheduler.sendStartingSoonNotifications();
+
+        verify(notificationService, times(1)).notifyGameStartingSoon(game, confirmedUser.getUserId());
+        verify(notificationService, times(1)).notifyGameStartingSoon(game, waitlistedUser.getUserId());
+        verify(notificationService, never()).notifyGameStartingSoon(game, organizer.getUserId());
+    }
+
+    @Test
+    void processPendingNotifications_DelegatesToNotificationService() {
+        scheduler.processPendingNotifications();
+        verify(notificationService).processPendingNotifications();
+    }
+
+    @Test
+    void sendStartingSoonNotifications_WhenNoGames_DoesNotNotifyAnyone() {
+        when(gameRepository.findGamesStartingSoon(any(), any())).thenReturn(List.of());
+
+        scheduler.sendStartingSoonNotifications();
+
+        verify(notificationService, never()).notifyGameStartingSoon(any(), any());
     }
 }

--- a/playlocal/backend/src/test/java/com/backend/playlocal/scheduler/GameLifecycleSchedulerTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/scheduler/GameLifecycleSchedulerTest.java
@@ -131,4 +131,22 @@ class GameLifecycleSchedulerTest {
 
         verify(notificationService, never()).notifyGameStartingSoon(any(), any());
     }
+
+    @Test
+    void sendStartingSoonNotifications_SkipsOrganizerIfPresentInWaitlist() {
+        GameParticipation organizerWaitlisted = GameParticipation.builder()
+                .game(game)
+                .user(organizer)
+                .joinStatus(GameParticipation.JoinStatus.WAITLISTED)
+                .waitlistPosition(1)
+                .build();
+
+        when(gameRepository.findGamesStartingSoon(any(), any())).thenReturn(List.of(game));
+        when(participationRepository.findConfirmedByGame(game.getGameId())).thenReturn(List.of());
+        when(participationRepository.findWaitlistedByGame(game.getGameId())).thenReturn(List.of(organizerWaitlisted));
+
+        scheduler.sendStartingSoonNotifications();
+
+        verify(notificationService, never()).notifyGameStartingSoon(game, organizer.getUserId());
+    }
 }

--- a/playlocal/backend/src/test/java/com/backend/playlocal/service/GameServiceLifecycleTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/service/GameServiceLifecycleTest.java
@@ -150,7 +150,7 @@ class GameServiceLifecycleTest {
 
         ArgumentCaptor<UUID> userCaptor = ArgumentCaptor.forClass(UUID.class);
         verify(notificationService, times(2))
-                .createInAppNotification(userCaptor.capture(), eq("game_cancelled"), anyMap());
+                .createInAppNotification(userCaptor.capture(), eq("GAME_CANCELLED"), anyMap());
         assertThat(userCaptor.getAllValues())
                 .containsExactlyInAnyOrder(confirmedUser.getUserId(), waitlistedUser.getUserId());
     }
@@ -172,6 +172,30 @@ class GameServiceLifecycleTest {
         ArgumentCaptor<Game> gameCaptor = ArgumentCaptor.forClass(Game.class);
         verify(gameRepository).save(gameCaptor.capture());
         assertThat(gameCaptor.getValue().getStatus()).isEqualTo(Game.GameStatus.COMPLETED);
+        verify(notificationService).notifyAttendanceConfirmationNeeded(gameCaptor.getValue());
+    }
+
+    @Test
+    void completeGame_WhenAlreadyCompleted_DoesNotSaveAgain() {
+        game.setStatus(Game.GameStatus.COMPLETED);
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.completeGame(gameId, organizer.getUserId());
+
+        verify(gameRepository, times(0)).save(any(Game.class));
+        verify(notificationService, times(0)).notifyAttendanceConfirmationNeeded(any(Game.class));
+    }
+
+    @Test
+    void completeGameByScheduler_CompletesAndNotifiesOrganizer() {
+        when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+
+        gameService.completeGameByScheduler(gameId);
+
+        ArgumentCaptor<Game> gameCaptor = ArgumentCaptor.forClass(Game.class);
+        verify(gameRepository).save(gameCaptor.capture());
+        assertThat(gameCaptor.getValue().getStatus()).isEqualTo(Game.GameStatus.COMPLETED);
+        verify(notificationService).notifyAttendanceConfirmationNeeded(gameCaptor.getValue());
     }
 
     @Test
@@ -280,6 +304,35 @@ class GameServiceLifecycleTest {
     }
 
     @Test
+    void leaveGame_WhenConfirmedUserLeaves_PromotesWaitlistedAndNotifies() {
+        GameParticipation leavingParticipation = GameParticipation.builder()
+                .game(game)
+                .user(confirmedUser)
+                .joinStatus(GameParticipation.JoinStatus.CONFIRMED)
+                .participationRole(GameParticipation.ParticipationRole.PARTICIPANT)
+                .build();
+        GameParticipation promotedParticipation = GameParticipation.builder()
+                .game(game)
+                .user(waitlistedUser)
+                .joinStatus(GameParticipation.JoinStatus.WAITLISTED)
+                .waitlistPosition(1)
+                .participationRole(GameParticipation.ParticipationRole.PARTICIPANT)
+                .build();
+
+        when(participationRepository.findByGameAndUser(gameId, confirmedUser.getUserId()))
+                .thenReturn(Optional.of(leavingParticipation));
+        when(participationRepository.findFirstWaitlisted(gameId))
+                .thenReturn(List.of(promotedParticipation));
+
+        gameService.leaveGame(gameId, confirmedUser.getUserId());
+
+        assertThat(promotedParticipation.getJoinStatus()).isEqualTo(GameParticipation.JoinStatus.CONFIRMED);
+        assertThat(promotedParticipation.getWaitlistPosition()).isNull();
+        verify(participationRepository).decrementWaitlistPositionsAfter(gameId, 1);
+        verify(notificationService).notifyWaitlistPromoted(game, waitlistedUser.getUserId());
+    }
+
+    @Test
     void cancelGame_WhenParticipantAppearsInBothLists_NotifiesOnlyOnce() {
         GameParticipation organizerParticipation = GameParticipation.builder()
                 .game(game)
@@ -306,7 +359,7 @@ class GameServiceLifecycleTest {
         gameService.cancelGame(gameId, organizer.getUserId());
 
         verify(notificationService, times(1))
-                .createInAppNotification(eq(confirmedUser.getUserId()), eq("game_cancelled"), anyMap());
+                .createInAppNotification(eq(confirmedUser.getUserId()), eq("GAME_CANCELLED"), anyMap());
     }
 
     @Test

--- a/playlocal/backend/src/test/java/com/backend/playlocal/service/NotificationServiceTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/service/NotificationServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,8 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -188,5 +191,140 @@ class NotificationServiceTest {
         assertThat(saved.getNotifType()).isEqualTo(NotificationService.TYPE_ATTENDANCE_PROMPT);
         assertThat(saved.getProviderMessageId())
                 .isEqualTo("IN_APP:ATTENDANCE_PROMPT:" + game.getGameId() + ":" + userId);
+    }
+
+    @Test
+    void scheduleAttendanceReminder_CreatesPendingInAppAndEmailNotifications() {
+        Game game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .title("Night Run")
+                .createdBy(user)
+                .build();
+        Instant scheduledFor = Instant.now().plusSeconds(1200);
+        when(notificationRepository.existsByProviderMessageId(anyString())).thenReturn(false);
+
+        List<Notification> savedNotifications = new ArrayList<>();
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> {
+            Notification saved = invocation.getArgument(0);
+            savedNotifications.add(saved);
+            return saved;
+        });
+
+        Notification inApp = notificationService.scheduleAttendanceReminder(game, scheduledFor);
+
+        assertThat(inApp).isNotNull();
+        assertThat(savedNotifications).hasSize(2);
+        assertThat(savedNotifications)
+                .extracting(Notification::getChannel)
+                .containsExactlyInAnyOrder(
+                        Notification.NotificationChannel.IN_APP,
+                        Notification.NotificationChannel.EMAIL);
+        assertThat(savedNotifications)
+                .extracting(Notification::getStatus)
+                .containsOnly(Notification.NotificationStatus.PENDING);
+        assertThat(savedNotifications)
+                .extracting(Notification::getProviderMessageId)
+                .allSatisfy(id -> assertThat(id).contains(game.getGameId().toString()).contains(userId.toString()));
+    }
+
+    @Test
+    void notifyWaitlistPromoted_CreatesTypedNotificationWithIdempotencyKey() {
+        Game game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .title("Pickup Volleyball")
+                .createdBy(user)
+                .build();
+        when(notificationRepository.existsByProviderMessageId(anyString())).thenReturn(false);
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+
+        notificationService.notifyWaitlistPromoted(game, userId);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getNotifType()).isEqualTo(NotificationService.TYPE_WAITLIST_PROMOTED);
+        assertThat(saved.getProviderMessageId())
+                .isEqualTo("IN_APP:WAITLIST_PROMOTED:" + game.getGameId() + ":" + userId);
+    }
+
+    @Test
+    void getUserNotifications_MapsEntitiesToDtos() {
+        Notification notification = Notification.builder()
+                .notificationId(UUID.randomUUID())
+                .notifType(NotificationService.TYPE_GAME_CANCELLED)
+                .payloadJson("{\"message\":\"cancelled\"}")
+                .status(Notification.NotificationStatus.SENT)
+                .scheduledFor(Instant.now())
+                .sentAt(Instant.now())
+                .build();
+        when(notificationRepository.findUserNotifications(userId)).thenReturn(List.of(notification));
+
+        List<NotificationService.NotificationDto> notifications = notificationService.getUserNotifications(userId);
+
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).type()).isEqualTo(NotificationService.TYPE_GAME_CANCELLED);
+        assertThat(notifications.get(0).payload()).isEqualTo("{\"message\":\"cancelled\"}");
+    }
+
+    @Test
+    void getUnreadCount_DelegatesToRepository() {
+        when(notificationRepository.countUnread(userId)).thenReturn(7);
+
+        int unread = notificationService.getUnreadCount(userId);
+
+        assertThat(unread).isEqualTo(7);
+    }
+
+    @Test
+    void markAllAsRead_UpdatesUnreadNotifications() {
+        Notification unread1 = Notification.builder()
+                .notificationId(UUID.randomUUID())
+                .status(Notification.NotificationStatus.SENT)
+                .build();
+        Notification unread2 = Notification.builder()
+                .notificationId(UUID.randomUUID())
+                .status(Notification.NotificationStatus.SENT)
+                .build();
+        when(notificationRepository.findUnreadNotifications(userId)).thenReturn(List.of(unread1, unread2));
+
+        notificationService.markAllAsRead(userId);
+
+        assertThat(unread1.getStatus()).isEqualTo(Notification.NotificationStatus.READ);
+        assertThat(unread2.getStatus()).isEqualTo(Notification.NotificationStatus.READ);
+        verify(notificationRepository).saveAll(List.of(unread1, unread2));
+    }
+
+    @Test
+    void createInAppNotification_WhenPayloadSerializationFails_StillSavesNotification() throws Exception {
+        ObjectMapper failingMapper = mock(ObjectMapper.class);
+        NotificationService service = new NotificationService(notificationRepository, userRepository, failingMapper);
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+        when(failingMapper.writeValueAsString(any())).thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("boom") {
+        });
+
+        service.createInAppNotification(userId, NotificationService.TYPE_GAME_CANCELLED, Map.of("message", "x"));
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getPayloadJson()).isNull();
+    }
+
+    @Test
+    void scheduleAttendanceReminder_WhenPayloadSerializationFails_StillCreatesNotifications() throws Exception {
+        ObjectMapper failingMapper = mock(ObjectMapper.class);
+        NotificationService service = new NotificationService(notificationRepository, userRepository, failingMapper);
+        Game game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .title("Serializer Edge")
+                .createdBy(user)
+                .build();
+        when(notificationRepository.existsByProviderMessageId(anyString())).thenReturn(false);
+        when(failingMapper.writeValueAsString(any())).thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("boom") {
+        });
+
+        Notification created = service.scheduleAttendanceReminder(game, Instant.now().plusSeconds(60));
+
+        assertThat(created).isNotNull();
+        verify(notificationRepository, times(2)).save(any(Notification.class));
     }
 }

--- a/playlocal/backend/src/test/java/com/backend/playlocal/service/NotificationServiceTest.java
+++ b/playlocal/backend/src/test/java/com/backend/playlocal/service/NotificationServiceTest.java
@@ -1,0 +1,192 @@
+package com.backend.playlocal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.backend.playlocal.model.entity.Game;
+import com.backend.playlocal.model.entity.Notification;
+import com.backend.playlocal.model.entity.User;
+import com.backend.playlocal.repository.NotificationRepository;
+import com.backend.playlocal.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private UUID userId;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(notificationRepository, userRepository, new ObjectMapper());
+        userId = UUID.randomUUID();
+        user = User.builder().userId(userId).email("user@example.com").displayName("User").build();
+    }
+
+    @Test
+    void markAsRead_WhenNotificationOwnedByUser_MarksRead() {
+        Notification notification = Notification.builder()
+                .notificationId(UUID.randomUUID())
+                .user(user)
+                .status(Notification.NotificationStatus.SENT)
+                .build();
+        when(notificationRepository.findByNotificationIdAndUser_UserId(notification.getNotificationId(), userId))
+                .thenReturn(Optional.of(notification));
+
+        boolean marked = notificationService.markAsRead(userId, notification.getNotificationId());
+
+        assertThat(marked).isTrue();
+        assertThat(notification.getStatus()).isEqualTo(Notification.NotificationStatus.READ);
+        verify(notificationRepository).save(notification);
+    }
+
+    @Test
+    void markAsRead_WhenNotificationBelongsToAnotherUser_DoesNothing() {
+        UUID notificationId = UUID.randomUUID();
+        when(notificationRepository.findByNotificationIdAndUser_UserId(notificationId, userId))
+                .thenReturn(Optional.empty());
+
+        boolean marked = notificationService.markAsRead(userId, notificationId);
+
+        assertThat(marked).isFalse();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void notifyGameStartingSoon_CreatesIdempotentInAppNotification() {
+        Game game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .title("Test Match")
+                .createdBy(user)
+                .startTime(Instant.now().plusSeconds(1800))
+                .build();
+        when(notificationRepository.existsByProviderMessageId(any())).thenReturn(false);
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+
+        notificationService.notifyGameStartingSoon(game, userId);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getNotifType()).isEqualTo(NotificationService.TYPE_GAME_STARTING_SOON);
+        assertThat(saved.getProviderMessageId())
+                .isEqualTo("IN_APP:GAME_STARTING_SOON:" + game.getGameId() + ":" + userId);
+        assertThat(saved.getStatus()).isEqualTo(Notification.NotificationStatus.SENT);
+    }
+
+    @Test
+    void createInAppNotification_WhenIdempotencyKeyExists_ReturnsNull() {
+        when(notificationRepository.existsByProviderMessageId("key-1")).thenReturn(true);
+
+        Notification created = notificationService.createInAppNotification(
+                userId,
+                NotificationService.TYPE_GAME_STARTING_SOON,
+                Map.of("message", "hello"),
+                "key-1");
+
+        assertThat(created).isNull();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void createInAppNotification_WhenUserMissing_ReturnsNull() {
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.empty());
+
+        Notification created = notificationService.createInAppNotification(
+                userId,
+                NotificationService.TYPE_GAME_CANCELLED,
+                Map.of("message", "cancelled"));
+
+        assertThat(created).isNull();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void scheduleAttendanceReminder_WhenAlreadyScheduled_ReturnsNull() {
+        Game game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .title("League Match")
+                .createdBy(user)
+                .build();
+        when(notificationRepository.existsByProviderMessageId(anyString())).thenReturn(true);
+
+        Notification scheduled = notificationService.scheduleAttendanceReminder(game, Instant.now().plusSeconds(300));
+
+        assertThat(scheduled).isNull();
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    void processPendingNotifications_MarksPendingAsSent() {
+        Notification emailPending = Notification.builder()
+                .notificationId(UUID.randomUUID())
+                .user(user)
+                .channel(Notification.NotificationChannel.EMAIL)
+                .notifType(NotificationService.TYPE_ATTENDANCE_PROMPT)
+                .status(Notification.NotificationStatus.PENDING)
+                .build();
+        Notification inAppPending = Notification.builder()
+                .notificationId(UUID.randomUUID())
+                .user(user)
+                .channel(Notification.NotificationChannel.IN_APP)
+                .notifType(NotificationService.TYPE_GAME_STARTING_SOON)
+                .status(Notification.NotificationStatus.PENDING)
+                .build();
+        when(notificationRepository.findPendingToSend(any())).thenReturn(List.of(emailPending, inAppPending));
+
+        notificationService.processPendingNotifications();
+
+        assertThat(emailPending.getStatus()).isEqualTo(Notification.NotificationStatus.SENT);
+        assertThat(emailPending.getSentAt()).isNotNull();
+        assertThat(inAppPending.getStatus()).isEqualTo(Notification.NotificationStatus.SENT);
+        assertThat(inAppPending.getSentAt()).isNotNull();
+        verify(notificationRepository).save(emailPending);
+        verify(notificationRepository).save(inAppPending);
+    }
+
+    @Test
+    void notifyAttendanceConfirmationNeeded_UsesOrganizerAndTypeConstant() {
+        Game game = Game.builder()
+                .gameId(UUID.randomUUID())
+                .title("Evening Soccer")
+                .createdBy(user)
+                .build();
+        when(notificationRepository.existsByProviderMessageId(anyString())).thenReturn(false);
+        when(userRepository.findActiveById(userId)).thenReturn(Optional.of(user));
+
+        notificationService.notifyAttendanceConfirmationNeeded(game);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getNotifType()).isEqualTo(NotificationService.TYPE_ATTENDANCE_PROMPT);
+        assertThat(saved.getProviderMessageId())
+                .isEqualTo("IN_APP:ATTENDANCE_PROMPT:" + game.getGameId() + ":" + userId);
+    }
+}

--- a/playlocal/frontend/components/NotificationsPage.tsx
+++ b/playlocal/frontend/components/NotificationsPage.tsx
@@ -52,6 +52,7 @@ const getNotificationIcon = (type: string) => {
     ),
     GAME_UPDATED: <Calendar className="w-5 h-5 text-emerald-600" />,
     GAME_STARTING: <Calendar className="w-5 h-5 text-amber-600" />,
+    GAME_STARTING_SOON: <Calendar className="w-5 h-5 text-amber-600" />,
     FRIEND_REQUEST: <UserPlus className="w-5 h-5 text-blue-600" />,
     MESSAGE: <MessageCircle className="w-5 h-5 text-amber-600" />,
     ACHIEVEMENT: <Award className="w-5 h-5 text-yellow-600" />,
@@ -146,10 +147,10 @@ export function NotificationsPage() {
   const { isAuthenticated } = useAuth();
   const {
     notifications: apiNotifications,
-    unreadCount: apiUnreadCount,
     isLoading,
     markAsRead,
     markAllAsRead,
+    refetch,
   } = useNotifications();
   const [filter, setFilter] = useState<'all' | 'unread'>('all');
   const [localReadState, setLocalReadState] = useState<Record<string, boolean>>(
@@ -184,6 +185,8 @@ export function NotificationsPage() {
       await markAsRead(notificationId);
     } catch (err) {
       // Already updated locally, so don't revert
+    } finally {
+      await refetch();
     }
   };
 
@@ -199,6 +202,8 @@ export function NotificationsPage() {
       await markAllAsRead();
     } catch (err) {
       // Already updated locally
+    } finally {
+      await refetch();
     }
   };
 

--- a/playlocal/frontend/hooks/useNotifications.ts
+++ b/playlocal/frontend/hooks/useNotifications.ts
@@ -44,10 +44,16 @@ function buildNotificationTitle(type: string): string {
   switch (type) {
     case 'GAME_CANCELLED':
       return 'Game cancelled';
+    case 'GAME_STARTING_SOON':
+      return 'Game starting soon';
     case 'GAME_UPDATED':
       return 'Game updated';
     case 'GAME_REMOVED_REQUIREMENTS':
       return 'Removed from game';
+    case 'WAITLIST_PROMOTED':
+      return 'Spot confirmed';
+    case 'ATTENDANCE_CONFIRMATION':
+      return 'Attendance confirmation needed';
     case 'ATTENDANCE_PROMPT':
       return 'Attendance reminder';
     default:

--- a/playlocal/frontend/test/components/NotificationsPage.test.tsx
+++ b/playlocal/frontend/test/components/NotificationsPage.test.tsx
@@ -114,6 +114,7 @@ function setup({
 } = {}) {
   const markAsRead = jest.fn(markAsReadImpl ?? (() => Promise.resolve()));
   const markAllAsRead = jest.fn(markAllAsReadImpl ?? (() => Promise.resolve()));
+  const refetch = jest.fn(() => Promise.resolve());
 
   useAuthMock.mockReturnValue({ isAuthenticated });
 
@@ -123,9 +124,10 @@ function setup({
     isLoading,
     markAsRead,
     markAllAsRead,
+    refetch,
   });
 
-  return { markAsRead, markAllAsRead };
+  return { markAsRead, markAllAsRead, refetch };
 }
 
 beforeEach(() => {

--- a/playlocal/frontend/test/hooks/useNotifications.test.ts
+++ b/playlocal/frontend/test/hooks/useNotifications.test.ts
@@ -108,6 +108,68 @@ describe('useNotifications', () => {
     expect(result.current.notifications[0].title).toBe('Removed from game');
   });
 
+  it('maps WAITLIST_PROMOTED and GAME_STARTING_SOON to user-friendly titles', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true } as any);
+    mockGetAll.mockResolvedValue([
+      {
+        notificationId: 'n1',
+        type: 'WAITLIST_PROMOTED',
+        payload: '{}',
+        status: 'SENT',
+        sentAt: '2026-02-08T10:00:00Z',
+      },
+      {
+        notificationId: 'n2',
+        type: 'GAME_STARTING_SOON',
+        payload: '{}',
+        status: 'SENT',
+        sentAt: '2026-02-08T11:00:00Z',
+      },
+    ]);
+    mockGetUnreadCount.mockResolvedValue({ count: 2 });
+
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.notifications[0].title).toBe('Spot confirmed');
+    expect(result.current.notifications[1].title).toBe('Game starting soon');
+  });
+
+  it('maps ATTENDANCE_CONFIRMATION and humanizes unknown types', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true } as any);
+    mockGetAll.mockResolvedValue([
+      {
+        notificationId: 'n1',
+        type: 'ATTENDANCE_CONFIRMATION',
+        payload: '{}',
+        status: 'SENT',
+        sentAt: '2026-02-08T10:00:00Z',
+      },
+      {
+        notificationId: 'n2',
+        type: 'NEW_BADGE_UNLOCKED',
+        payload: '{}',
+        status: 'SENT',
+        sentAt: '2026-02-08T11:00:00Z',
+      },
+    ]);
+    mockGetUnreadCount.mockResolvedValue({ count: 2 });
+
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.notifications[0].title).toBe(
+      'Attendance confirmation needed'
+    );
+    expect(result.current.notifications[1].title).toBe('New Badge Unlocked');
+  });
+
   it('markAsRead dispatches playlocal-refresh-notifications event on success', async () => {
     const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
     const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');


### PR DESCRIPTION
---
name: 'Pull Request'
title: 'PR-US2.8: Implement MVP in-app notifications inbox and lifecycle triggers #13 '
assignees: @elshito 

---

# Pull Request

## Description

Implements User Story 2.8 end-to-end for in-app notifications (backend persistence + frontend inbox UX), including required event triggers, read-state management, ownership/security checks, idempotency, scheduler wiring, and targeted test coverage updates.

Closes #13

## Type of Change

- [ ] Bug fix
- [x] New feature (User Story)
- [ ] Task implementation
- [ ] Documentation update
- [x] Code refactoring
- [x] Unit tests
- [ ] Other (please describe)

## Related Issues

- Implements: #13
- Fixes: #13
- Related to: EPIC 2 (Core Loop: Game Lifecycle & Reliability Engine)

## All relevant files to this PR

- `playlocal/backend/src/main/java/com/backend/playlocal/repository/NotificationRepository.java`
- `playlocal/backend/src/main/java/com/backend/playlocal/repository/GameRepository.java`
- `playlocal/backend/src/main/java/com/backend/playlocal/service/NotificationService.java`
- `playlocal/backend/src/main/java/com/backend/playlocal/controller/NotificationController.java`
- `playlocal/backend/src/main/java/com/backend/playlocal/service/GameService.java`
- `playlocal/backend/src/main/java/com/backend/playlocal/scheduler/GameLifecycleScheduler.java`
- `playlocal/backend/src/test/java/com/backend/playlocal/service/NotificationServiceTest.java`
- `playlocal/backend/src/test/java/com/backend/playlocal/controller/NotificationControllerTest.java`
- `playlocal/backend/src/test/java/com/backend/playlocal/scheduler/GameLifecycleSchedulerTest.java`
- `playlocal/backend/src/test/java/com/backend/playlocal/service/GameServiceLifecycleTest.java`
- `playlocal/frontend/hooks/useNotifications.ts`
- `playlocal/frontend/components/NotificationsPage.tsx`
- `playlocal/frontend/test/hooks/useNotifications.test.ts`
- `playlocal/frontend/test/components/NotificationsPage.test.tsx`

## Requirements Reference [Mandatory for User Stories]

View all requirements in the [Project Requirements](https://github.com/munera-intelligence/PermitParser/wiki/Project-Requirements)

**Requirement Reference:** US 2.8 Acceptance Criteria (AC1-AC5)  
- AC1: Notifications inbox with bell/inbox view  
- AC2: Required types (game starting soon, waitlist promoted, game cancelled, attendance confirmation needed)  
- AC3: Mark as read support  
- AC4: Backend persistence and refresh reload  
- AC5: Production-ready behavior and edge handling (ownership, dedupe, scheduler-safe flow)

**Justification:**  
This PR adds full backend + frontend wiring for all required notification types, enforces read ownership checks, uses idempotency keys to prevent duplicates, ensures notifications persist in DB and are loaded on refresh, and updates UI behavior/tests to align read/unread state with backend source of truth.

## Risk Mitigation [Mandatory for User Stories]

**Associated Risks:** duplicate notifications from schedulers/retries, unauthorized read-state updates, missed lifecycle triggers, frontend/backend state drift, regression in lifecycle flows.

**Mitigation Strategy:** Fix now for critical risks; defer only non-blocking lint warnings not introduced by this story.

**Details:**  
- Duplicate sends mitigated via idempotency checks (`providerMessageId` usage and existence checks).  
- Unauthorized mark-as-read mitigated by user-scoped lookup (`notificationId + userId`).  
- Lifecycle trigger gaps addressed in `GameService` + `GameLifecycleScheduler` for required events.  
- State drift mitigated with frontend `refetch` reconciliation after read actions.  
- Regressions mitigated via new/updated backend and frontend unit tests and full suite runs.

## Technical Requirements

- [x] Code follows project standards and guidelines [see wiki](https://github.com/MuneraCappin/PermitParser/wiki/Code-Standards)
- [ ] Architecture diagrams updated if needed [see wiki](https://github.com/MuneraCappin/PermitParser/wiki/System-Diagrams)

## Unit Tests

**Unit Test Status:** Completed

**Test Documentation:** [QA Test Results](https://github.com/MuneraCappin/PermitParser/wiki/QA-Test-Results)

- [x] Unit tests written
- [x] Code coverage >80% (frontend suite reports >80% overall)
- [ ] Unit tests documented
- [x] All tests passing

## Related Links

**Architecture Diagrams:** N/A for this change set (no architecture diagram delta required)

## Customer Signoff

- [ ] Requirements reviewed with customer/stakeholder
- [ ] Acceptance criteria approved
- [ ] Customer signoff received (add customer-approved label when complete)

## Definition of Done

- [x] Code implemented and follows standards
- [x] Risk mitigation addressed
- [ ] Documentation updated
- [ ] Story tagged in git when completed
- [ ] PR reviewed and risks audited

## Additional Notes

- Commits are intentionally granular (one logical change per commit) for easier review/audit.
- Local cache folder `playlocal/backend/.m2/` remains untracked and is not part of the PR.
- Frontend lint completes with warnings only (no errors); build and tests pass.