### PR TITLE
181 us 78 settings hub (overall settings page & basic functionalities)

### DIFF
--- a/playlocal/backend/src/main/resources/application-dev.yml
+++ b/playlocal/backend/src/main/resources/application-dev.yml
@@ -1,6 +1,9 @@
 spring:
   flyway:
     locations: classpath:db/migration,classpath:db/migration-dev
+  datasource:
+    # When using Docker for Postgres only (docker compose up postgres -d), use host port 5439
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5439/playlocal}
   jpa:
     show-sql: true
 

--- a/playlocal/frontend/app/settings/account/page.tsx
+++ b/playlocal/frontend/app/settings/account/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { AccountSettings } from '@/components/SettingsPage';
+
+export default function AccountSettingsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Link
+          href="/settings"
+          className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Settings
+        </Link>
+        <div className="space-y-6">
+          <AccountSettings />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playlocal/frontend/app/settings/deactivation/page.tsx
+++ b/playlocal/frontend/app/settings/deactivation/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { DeactivationSettings } from '@/components/SettingsPage';
+
+export default function DeactivationSettingsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Link
+          href="/settings"
+          className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Settings
+        </Link>
+        <div className="space-y-6">
+          <DeactivationSettings />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playlocal/frontend/app/settings/layout.tsx
+++ b/playlocal/frontend/app/settings/layout.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ProtectedRoute } from '@/components/ProtectedRoute';
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <ProtectedRoute>{children}</ProtectedRoute>;
+}

--- a/playlocal/frontend/app/settings/layout.tsx
+++ b/playlocal/frontend/app/settings/layout.tsx
@@ -1,19 +1,23 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { SettingsLoading, SettingsError } from '@/components/SettingsPage';
 
+/** Top-level render fn so we don’t define a component inside `SettingsLayout` (Sonar). */
+function renderSettingsErrorContent(error: string, retry: () => void) {
+  return <SettingsError message={error} onRetry={retry} />;
+}
+
 export default function SettingsLayout({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}: Readonly<{
+  children: ReactNode;
+}>) {
   return (
     <ProtectedRoute
       loadingContent={<SettingsLoading />}
-      errorContent={(error, retry) => (
-        <SettingsError message={error} onRetry={retry} />
-      )}
+      errorContent={renderSettingsErrorContent}
     >
       {children}
     </ProtectedRoute>

--- a/playlocal/frontend/app/settings/layout.tsx
+++ b/playlocal/frontend/app/settings/layout.tsx
@@ -1,11 +1,21 @@
 'use client';
 
 import { ProtectedRoute } from '@/components/ProtectedRoute';
+import { SettingsLoading, SettingsError } from '@/components/SettingsPage';
 
 export default function SettingsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <ProtectedRoute>{children}</ProtectedRoute>;
+  return (
+    <ProtectedRoute
+      loadingContent={<SettingsLoading />}
+      errorContent={(error, retry) => (
+        <SettingsError message={error} onRetry={retry} />
+      )}
+    >
+      {children}
+    </ProtectedRoute>
+  );
 }

--- a/playlocal/frontend/app/settings/notifications/page.tsx
+++ b/playlocal/frontend/app/settings/notifications/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { NotificationSettings } from '@/components/SettingsPage';
+
+export default function NotificationSettingsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Link
+          href="/settings"
+          className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Settings
+        </Link>
+        <div className="space-y-6">
+          <NotificationSettings />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playlocal/frontend/app/settings/page.tsx
+++ b/playlocal/frontend/app/settings/page.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import { SettingsPage } from '@/components/SettingsPage';
-
-import { ProtectedRoute } from '@/components/ProtectedRoute';
+import { SettingsHub } from '@/components/SettingsPage';
 
 export default function Page() {
-  return (
-    <ProtectedRoute>
-      <SettingsPage />
-    </ProtectedRoute>
-  );
+  return <SettingsHub />;
 }

--- a/playlocal/frontend/app/settings/privacy/page.tsx
+++ b/playlocal/frontend/app/settings/privacy/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { PrivacySettings } from '@/components/SettingsPage';
+
+export default function PrivacySettingsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Link
+          href="/settings"
+          className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Settings
+        </Link>
+        <div className="space-y-6">
+          <PrivacySettings />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playlocal/frontend/app/settings/profile/page.tsx
+++ b/playlocal/frontend/app/settings/profile/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { useAuth } from '@/context/AuthContext';
+import { ProfileSettings } from '@/components/SettingsPage';
+
+export default function ProfileSettingsPage() {
+  const { user } = useAuth();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Link
+          href="/settings"
+          className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Settings
+        </Link>
+        <div className="space-y-6">
+          <ProfileSettings user={user} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playlocal/frontend/components/Navigation.tsx
+++ b/playlocal/frontend/components/Navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -14,6 +14,8 @@ import {
   LogOut,
   LogIn,
   Bot,
+  Settings,
+  ChevronDown,
 } from 'lucide-react';
 import { useAssistant } from '@/context/AssistantContext';
 import { inferAssistantRoute } from '@/lib/inferAssistantRoute';
@@ -24,6 +26,8 @@ import { performLogoutRedirect } from '@/lib/authRedirect';
 
 export function Navigation() {
   const [mounted, setMounted] = useState(false);
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const profileMenuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
 
   // Ensure hydration is complete before rendering
@@ -31,6 +35,27 @@ export function Navigation() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
   }, []);
+
+  // Close profile menu when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        profileMenuRef.current &&
+        !profileMenuRef.current.contains(event.target as Node)
+      ) {
+        setProfileMenuOpen(false);
+      }
+    }
+    if (profileMenuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [profileMenuOpen]);
+
+  // Close menu when route changes (e.g. after navigating to Settings)
+  useEffect(() => {
+    setProfileMenuOpen(false);
+  }, [pathname]);
 
   const isLanding = pathname === '/';
   const isMobile = useIsMobile();
@@ -196,31 +221,73 @@ export function Navigation() {
                   )}
                 </Link>
 
-                <Link
-                  href="/profile"
-                  className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
-                    pathname.startsWith('/profile')
-                      ? 'text-emerald-600 bg-emerald-50'
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
-                  }`}
-                >
-                  {user?.displayName ? (
-                    <div className="w-6 h-6 bg-gradient-to-br from-emerald-500 to-teal-500 rounded-full flex items-center justify-center text-white text-xs font-medium">
-                      {user.displayName[0].toUpperCase()}
-                    </div>
-                  ) : (
-                    <User className="w-5 h-5" />
-                  )}
-                  <span>{user?.displayName || 'Profile'}</span>
-                </Link>
+                {/* Profile / avatar menu: Profile, Settings, Sign out */}
+                <div className="relative" ref={profileMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setProfileMenuOpen((open) => !open)}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
+                      pathname.startsWith('/profile') || pathname.startsWith('/settings')
+                        ? 'text-emerald-600 bg-emerald-50'
+                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+                    }`}
+                    aria-expanded={profileMenuOpen}
+                    aria-haspopup="true"
+                    aria-label="Open account menu"
+                  >
+                    {user?.displayName ? (
+                      <div className="w-6 h-6 bg-gradient-to-br from-emerald-500 to-teal-500 rounded-full flex items-center justify-center text-white text-xs font-medium">
+                        {user.displayName[0].toUpperCase()}
+                      </div>
+                    ) : (
+                      <User className="w-5 h-5" />
+                    )}
+                    <span>{user?.displayName || 'Profile'}</span>
+                    <ChevronDown
+                      className="w-4 h-4 shrink-0 transition-transform duration-200"
+                      style={{ transform: profileMenuOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+                    />
+                  </button>
 
-                <button
-                  onClick={handleLogout}
-                  className="p-2 text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                  title="Sign out"
-                >
-                  <LogOut className="w-5 h-5" />
-                </button>
+                  {profileMenuOpen && (
+                    <div
+                      className="absolute right-0 mt-1 w-52 py-1 bg-white rounded-lg border border-gray-200 shadow-lg z-50"
+                      role="menu"
+                    >
+                      <Link
+                        href="/profile"
+                        className="flex items-center gap-3 px-4 py-2.5 text-gray-700 hover:bg-gray-50 transition-colors"
+                        role="menuitem"
+                        onClick={() => setProfileMenuOpen(false)}
+                      >
+                        <User className="w-5 h-5 text-gray-500" />
+                        <span>Profile</span>
+                      </Link>
+                      <Link
+                        href="/settings"
+                        className="flex items-center gap-3 px-4 py-2.5 text-gray-700 hover:bg-gray-50 transition-colors"
+                        role="menuitem"
+                        onClick={() => setProfileMenuOpen(false)}
+                      >
+                        <Settings className="w-5 h-5 text-gray-500" />
+                        <span>Settings</span>
+                      </Link>
+                      <hr className="my-1 border-gray-100" />
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setProfileMenuOpen(false);
+                          handleLogout();
+                        }}
+                        className="flex items-center gap-3 w-full px-4 py-2.5 text-left text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors"
+                        role="menuitem"
+                      >
+                        <LogOut className="w-5 h-5 text-gray-500" />
+                        <span>Sign out</span>
+                      </button>
+                    </div>
+                  )}
+                </div>
               </>
             ) : (
               <>

--- a/playlocal/frontend/components/Navigation.tsx
+++ b/playlocal/frontend/components/Navigation.tsx
@@ -54,6 +54,7 @@ export function Navigation() {
 
   // Close menu when route changes (e.g. after navigating to Settings)
   useEffect(() => {
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- close dropdown on navigate; recommended UX */
     setProfileMenuOpen(false);
   }, [pathname]);
 

--- a/playlocal/frontend/components/PlayerSearch.tsx
+++ b/playlocal/frontend/components/PlayerSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import {
   Search,
@@ -88,8 +88,14 @@ export function PlayerSearch() {
     searchPlayers('');
   }, [fetchFriendsList, searchPlayers]);
 
-  // Search on query change (debounced)
+  const skipNextDebouncedSearch = useRef(true);
+
+  // Search on query change (debounced); skip first run — initial load already searches above
   useEffect(() => {
+    if (skipNextDebouncedSearch.current) {
+      skipNextDebouncedSearch.current = false;
+      return;
+    }
     const timer = setTimeout(() => {
       searchPlayers(searchQuery);
     }, 300);

--- a/playlocal/frontend/components/ProtectedRoute.tsx
+++ b/playlocal/frontend/components/ProtectedRoute.tsx
@@ -5,11 +5,11 @@ import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
 
 interface ProtectedRouteProps {
-  children: React.ReactNode;
+  readonly children: React.ReactNode;
   /** Optional custom loading UI (e.g. "Loading settings...") */
-  loadingContent?: React.ReactNode;
+  readonly loadingContent?: React.ReactNode;
   /** Optional custom error UI (error message, retry callback). AC6. */
-  errorContent?: (error: string, retry: () => void) => React.ReactNode;
+  readonly errorContent?: (error: string, retry: () => void) => React.ReactNode;
 }
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({

--- a/playlocal/frontend/components/ProtectedRoute.tsx
+++ b/playlocal/frontend/components/ProtectedRoute.tsx
@@ -6,27 +6,58 @@ import { useAuth } from '@/context/AuthContext';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  /** Optional custom loading UI (e.g. "Loading settings...") */
+  loadingContent?: React.ReactNode;
+  /** Optional custom error UI (error message, retry callback). AC6. */
+  errorContent?: (error: string, retry: () => void) => React.ReactNode;
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-  const { isAuthenticated, isLoading } = useAuth();
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  loadingContent,
+  errorContent,
+}) => {
+  const { isAuthenticated, isLoading, error, retryAuthCheck } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    if (!isLoading && !isAuthenticated && !error) {
       router.replace(`/login?from=${encodeURIComponent(pathname)}`);
     }
-  }, [isLoading, isAuthenticated, router, pathname]);
+  }, [isLoading, isAuthenticated, error, router, pathname]);
 
-  // Show loading while checking auth status
+  // Show loading while checking auth status (or fetching settings, etc.)
   if (isLoading) {
+    if (loadingContent) {
+      return <>{loadingContent}</>;
+    }
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-6 py-4 shadow-sm">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-600"></div>
           <span className="text-gray-700">Checking your session...</span>
         </div>
+      </div>
+    );
+  }
+
+  // AC6: Show clear error message with retry when auth/settings load failed
+  if (!isAuthenticated && error) {
+    const retry = () => void retryAuthCheck();
+    if (errorContent) {
+      return <>{errorContent(error, retry)}</>;
+    }
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4">
+        <p className="text-gray-700 text-center mb-4">{error}</p>
+        <button
+          type="button"
+          onClick={retry}
+          className="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors"
+        >
+          Try again
+        </button>
       </div>
     );
   }

--- a/playlocal/frontend/components/SettingsPage.tsx
+++ b/playlocal/frontend/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   CheckCircle2,
   ShieldCheck,
+  AlertCircle,
 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import {
@@ -237,6 +238,33 @@ function codeToLabel(map: Record<string, string>, code: string): string {
   return entry ? entry[0] : Object.keys(map)[0];
 }
 
+const SKILLS_VISIBILITY_MAP: Record<string, string> = {
+  Public: 'public',
+  'Friends Only': 'friends',
+  'Participants Only': 'participants',
+  Private: 'private',
+};
+
+const HISTORY_VISIBILITY_MAP: Record<string, string> = {
+  Public: 'public',
+  'Friends Only': 'friends',
+  Private: 'private',
+};
+
+const MEDIA_VISIBILITY_MAP: Record<string, string> = {
+  Public: 'public',
+  Friends: 'friends',
+  Participants: 'participants',
+  Private: 'private',
+};
+
+const LOCATION_RULE_MAP: Record<string, string> = {
+  Always: 'always_visible',
+  'After Accepted': 'confirmed_only',
+  'After Check-in': 'approximate',
+  Never: 'hidden',
+};
+
 function PrivacySettings({
   initialSettings,
   initialLoading,
@@ -254,6 +282,10 @@ function PrivacySettings({
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [error, setError] = useState<string | null>(initialError);
 
+  useEffect(() => {
+    setError(initialError);
+  }, [initialError]);
+
   const handleUpdate = useCallback(
     async (update: UpdatePrivacySettingsRequest) => {
       setIsSaving(true);
@@ -264,8 +296,12 @@ function PrivacySettings({
         onSettingsChange(updated);
         setSaveSuccess(true);
         setTimeout(() => setSaveSuccess(false), 2000);
-      } catch (err: any) {
-        setError(err.message || 'Failed to save privacy settings');
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Failed to save privacy settings';
+        setError(message);
       } finally {
         setIsSaving(false);
       }
@@ -319,6 +355,48 @@ function PrivacySettings({
               })
             }
           />
+          <PrivacySetting
+            label="Skills Visibility"
+            description="Control who can see your skill ratings."
+            options={Object.keys(SKILLS_VISIBILITY_MAP)}
+            value={codeToLabel(
+              SKILLS_VISIBILITY_MAP,
+              settings?.skillsVisibility || 'public'
+            )}
+            onChange={(label) =>
+              handleUpdate({
+                skillsVisibility: SKILLS_VISIBILITY_MAP[label],
+              })
+            }
+          />
+          <PrivacySetting
+            label="Game History Visibility"
+            description="Control who can see your past games."
+            options={Object.keys(HISTORY_VISIBILITY_MAP)}
+            value={codeToLabel(
+              HISTORY_VISIBILITY_MAP,
+              settings?.historyVisibility || 'public'
+            )}
+            onChange={(label) =>
+              handleUpdate({
+                historyVisibility: HISTORY_VISIBILITY_MAP[label],
+              })
+            }
+          />
+          <PrivacySetting
+            label="Media Default Visibility"
+            description="Default visibility for uploaded photos and videos."
+            options={Object.keys(MEDIA_VISIBILITY_MAP)}
+            value={codeToLabel(
+              MEDIA_VISIBILITY_MAP,
+              settings?.mediaDefaultVisibility || 'participants'
+            )}
+            onChange={(label) =>
+              handleUpdate({
+                mediaDefaultVisibility: MEDIA_VISIBILITY_MAP[label],
+              })
+            }
+          />
         </div>
         <div className="mt-6 pt-6 border-t border-gray-200">
           <ToggleSetting
@@ -329,6 +407,35 @@ function PrivacySettings({
               handleUpdate({ allowProfileSearch: enabled })
             }
           />
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <h2 className="text-xl text-gray-900 mb-6">Location Privacy</h2>
+        <div className="space-y-6">
+          <PrivacySetting
+            label="Location Visibility"
+            description="Control when others can see game locations."
+            options={Object.keys(LOCATION_RULE_MAP)}
+            value={codeToLabel(
+              LOCATION_RULE_MAP,
+              settings?.locationVisibilityRule || 'confirmed_only'
+            )}
+            onChange={(label) =>
+              handleUpdate({
+                locationVisibilityRule: LOCATION_RULE_MAP[label],
+              })
+            }
+          />
+          <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg">
+            <div className="flex gap-3">
+              <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+              <div className="text-sm text-amber-800">
+                For safety reasons, exact locations are only shared with accepted
+                participants. You can customize this for each game.
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/playlocal/frontend/components/SettingsPage.tsx
+++ b/playlocal/frontend/components/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import {
   User,
   Lock,
@@ -12,6 +13,8 @@ import {
   CheckCircle2,
   ShieldCheck,
   AlertCircle,
+  UserX,
+  ArrowLeft,
 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import {
@@ -25,6 +28,73 @@ import { toast, getActionableErrorMessage } from '@/lib/toast';
 import { ConfirmAccountActionDialog } from './ConfirmAccountActionDialog';
 import { PasswordChangeCard } from '@/components/PasswordChangeCard';
 import { performLogoutRedirect } from '@/lib/authRedirect';
+
+/** AC4: Hub listing links to each settings subpage (each subpage has back navigation). */
+export function SettingsHub() {
+  const sections = [
+    {
+      href: '/settings/account',
+      icon: Lock,
+      label: 'Account',
+      description: 'Password & security',
+    },
+    {
+      href: '/settings/privacy',
+      icon: Eye,
+      label: 'Privacy / Visibility',
+      description: 'Profile and location privacy',
+    },
+    {
+      href: '/settings/profile',
+      icon: User,
+      label: 'Profile',
+      description: 'Display name, bio, preferences',
+    },
+    {
+      href: '/settings/notifications',
+      icon: Bell,
+      label: 'Notifications',
+      description: 'Game, social & email preferences',
+    },
+    {
+      href: '/settings/deactivation',
+      icon: UserX,
+      label: 'Deactivation',
+      description: 'Deactivate or delete account',
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl text-gray-900 mb-2">Settings</h1>
+          <p className="text-gray-600">
+            Manage your account and privacy preferences
+          </p>
+        </div>
+        <div className="space-y-3">
+          {sections.map(({ href, icon: Icon, label, description }) => (
+            <Link
+              key={href}
+              href={href}
+              className="flex items-center gap-4 p-4 bg-white rounded-xl border border-gray-200 hover:border-emerald-300 hover:bg-emerald-50/50 transition-colors"
+            >
+              <div className="w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center flex-shrink-0">
+                <Icon className="w-5 h-5 text-emerald-700" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-gray-900">{label}</div>
+                <div className="text-sm text-gray-500">{description}</div>
+              </div>
+              <ArrowLeft className="w-5 h-5 text-gray-400 rotate-180 flex-shrink-0" />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function SettingsPage() {
   const { user } = useAuth();
@@ -265,26 +335,59 @@ const LOCATION_RULE_MAP: Record<string, string> = {
   Never: 'hidden',
 };
 
-function PrivacySettings({
+export function PrivacySettings({
   initialSettings,
   initialLoading,
   initialError,
   onSettingsChange,
-}: Readonly<{
-  initialSettings: PrivacySettingsResponse | null;
-  initialLoading: boolean;
-  initialError: string | null;
-  onSettingsChange: (settings: PrivacySettingsResponse | null) => void;
-}>) {
-  const settings = initialSettings;
-  const isLoading = initialLoading;
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveSuccess, setSaveSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(initialError);
+}: {
+  initialSettings?: PrivacySettingsResponse | null;
+  initialLoading?: boolean;
+  initialError?: string | null;
+  onSettingsChange?: (settings: PrivacySettingsResponse | null) => void;
+} = {}) {
+  const controlled = onSettingsChange !== undefined;
+
+  const [localSettings, setLocalSettings] =
+    useState<PrivacySettingsResponse | null>(null);
+  const [localLoading, setLocalLoading] = useState(true);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   useEffect(() => {
-    setError(initialError);
-  }, [initialError]);
+    if (controlled) return;
+    privacyApi
+      .getSettings()
+      .then((data) => {
+        setLocalSettings(data);
+        setLocalLoading(false);
+      })
+      .catch((err) => {
+        setLocalError(err.message || 'Failed to load privacy settings');
+        setLocalLoading(false);
+      });
+  }, [controlled]);
+
+  const settings = controlled ? (initialSettings ?? null) : localSettings;
+  const isLoading = controlled ? (initialLoading ?? true) : localLoading;
+  const serverError = controlled
+    ? (initialError ?? null)
+    : localError;
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(serverError);
+
+  useEffect(() => {
+    setError(serverError);
+  }, [serverError]);
+
+  const handleSettingsChange = useCallback(
+    (next: PrivacySettingsResponse | null) => {
+      if (controlled) onSettingsChange!(next);
+      else setLocalSettings(next);
+    },
+    [controlled, onSettingsChange]
+  );
 
   const handleUpdate = useCallback(
     async (update: UpdatePrivacySettingsRequest) => {
@@ -293,7 +396,7 @@ function PrivacySettings({
       setError(null);
       try {
         const updated = await privacyApi.updateSettings(update);
-        onSettingsChange(updated);
+        handleSettingsChange(updated);
         setSaveSuccess(true);
         setTimeout(() => setSaveSuccess(false), 2000);
       } catch (err: unknown) {
@@ -306,7 +409,7 @@ function PrivacySettings({
         setIsSaving(false);
       }
     },
-    [onSettingsChange]
+    [handleSettingsChange]
   );
 
   if (isLoading) {
@@ -466,7 +569,7 @@ function PrivacySettings({
   );
 }
 
-function NotificationSettings() {
+export function NotificationSettings() {
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-6">
       <h2 className="text-xl text-gray-900 mb-6">Notification Preferences</h2>
@@ -560,18 +663,124 @@ function NotificationSettings() {
   );
 }
 
+export function DeactivationSettings() {
+  const [showAccountDialog, setShowAccountDialog] = useState(false);
+  const [accountAction, setAccountAction] = useState<
+    'deactivate' | 'delete' | null
+  >(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [redirectingAction, setRedirectingAction] = useState<
+    'deactivate' | 'delete' | null
+  >(null);
+
+  const handleAccountAction = async () => {
+    if (!accountAction) return;
+
+    const pendingAction = accountAction;
+    setShowAccountDialog(false);
+    setRedirectingAction(pendingAction);
+    setIsProcessing(true);
+    try {
+      if (pendingAction === 'deactivate') {
+        await usersApi.deactivateAccount();
+        performLogoutRedirect('/', {
+          message: 'Account deactivated',
+          type: 'success',
+        });
+      } else {
+        await usersApi.deleteAccount();
+        performLogoutRedirect('/', {
+          message: 'Account deleted',
+          type: 'success',
+        });
+      }
+    } catch (err: unknown) {
+      setRedirectingAction(null);
+      const errorMessage = getActionableErrorMessage(
+        err,
+        `${pendingAction} account`
+      );
+      toast.error(errorMessage);
+    } finally {
+      setIsProcessing(false);
+      setAccountAction(null);
+    }
+  };
+
+  return (
+    <>
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <h2 className="text-xl text-gray-900 mb-6">Account Actions</h2>
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={() => {
+              setAccountAction('deactivate');
+              setShowAccountDialog(true);
+            }}
+            className="flex items-center gap-3 w-full px-4 py-3 text-left text-gray-700 hover:bg-gray-50 rounded-lg transition-colors"
+          >
+            <Lock className="w-5 h-5 text-gray-400" />
+            <div>
+              <div>Deactivate Account</div>
+              <div className="text-sm text-gray-600">
+                Temporarily disable your account
+              </div>
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setAccountAction('delete');
+              setShowAccountDialog(true);
+            }}
+            className="flex items-center gap-3 w-full px-4 py-3 text-left text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          >
+            <Trash2 className="w-5 h-5" />
+            <div>
+              <div>Delete Account</div>
+              <div className="text-sm text-red-600">
+                Permanently delete your account and all data
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      {accountAction && (
+        <ConfirmAccountActionDialog
+          isOpen={showAccountDialog}
+          onClose={() => {
+            setShowAccountDialog(false);
+            setAccountAction(null);
+          }}
+          onConfirm={handleAccountAction}
+          action={accountAction}
+          isLoading={isProcessing}
+        />
+      )}
+
+      {redirectingAction && (
+        <div className="fixed inset-0 z-[10001] flex items-center justify-center bg-white/80 backdrop-blur-sm">
+          <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-6 py-4 shadow-sm">
+            <Loader2 className="h-6 w-6 animate-spin text-emerald-600" />
+            <span className="text-gray-700">
+              {redirectingAction === 'deactivate'
+                ? 'Deactivating account...'
+                : 'Deleting account...'}
+            </span>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
 function SecuritySettings() {
   const [mfaEnabled, setMfaEnabled] = useState(false);
   const [mfaLoading, setMfaLoading] = useState(true);
   const [mfaToggling, setMfaToggling] = useState(false);
   const [mfaMessage, setMfaMessage] = useState<string | null>(null);
-
-  const [showAccountDialog, setShowAccountDialog] = useState(false);
-  const [accountAction, setAccountAction] = useState<'deactivate' | 'delete' | null>(null);
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [redirectingAction, setRedirectingAction] = useState<
-    'deactivate' | 'delete' | null
-  >(null);
 
   useEffect(() => {
     authApi.getMfaStatus()
@@ -600,41 +809,6 @@ function SecuritySettings() {
       setMfaToggling(false);
     }
   };
-
-  const handleAccountAction = async () => {
-    if (!accountAction) return;
-
-    const pendingAction = accountAction;
-    setShowAccountDialog(false);
-    setRedirectingAction(pendingAction);
-    setIsProcessing(true);
-    try {
-      if (pendingAction === 'deactivate') {
-        await usersApi.deactivateAccount();
-        performLogoutRedirect('/', {
-          message: 'Account deactivated',
-          type: 'success',
-        });
-      } else {
-        await usersApi.deleteAccount();
-        performLogoutRedirect('/', {
-          message: 'Account deleted',
-          type: 'success',
-        });
-      }
-    } catch (err: any) {
-      setRedirectingAction(null);
-      const errorMessage = getActionableErrorMessage(
-        err,
-        `${pendingAction} account`
-      );
-      toast.error(errorMessage);
-    } finally {
-      setIsProcessing(false);
-      setAccountAction(null);
-    }
-  };
-
 
   return (
     <>
@@ -698,68 +872,7 @@ function SecuritySettings() {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="text-xl text-gray-900 mb-6">Account Actions</h2>
-        <div className="space-y-3">
-          <button
-            onClick={() => {
-              setAccountAction('deactivate');
-              setShowAccountDialog(true);
-            }}
-            className="flex items-center gap-3 w-full px-4 py-3 text-left text-gray-700 hover:bg-gray-50 rounded-lg transition-colors"
-          >
-            <Lock className="w-5 h-5 text-gray-400" />
-            <div>
-              <div>Deactivate Account</div>
-              <div className="text-sm text-gray-600">
-                Temporarily disable your account
-              </div>
-            </div>
-          </button>
-          <button
-            onClick={() => {
-              setAccountAction('delete');
-              setShowAccountDialog(true);
-            }}
-            className="flex items-center gap-3 w-full px-4 py-3 text-left text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-          >
-            <Trash2 className="w-5 h-5" />
-            <div>
-              <div>Delete Account</div>
-              <div className="text-sm text-red-600">
-                Permanently delete your account and all data
-              </div>
-            </div>
-          </button>
-        </div>
-      </div>
-
-      {/* Account Action Confirmation Dialog */}
-      {accountAction && (
-        <ConfirmAccountActionDialog
-          isOpen={showAccountDialog}
-          onClose={() => {
-            setShowAccountDialog(false);
-            setAccountAction(null);
-          }}
-          onConfirm={handleAccountAction}
-          action={accountAction}
-          isLoading={isProcessing}
-        />
-      )}
-
-      {redirectingAction && (
-        <div className="fixed inset-0 z-[10001] flex items-center justify-center bg-white/80 backdrop-blur-sm">
-          <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-6 py-4 shadow-sm">
-            <Loader2 className="h-6 w-6 animate-spin text-emerald-600" />
-            <span className="text-gray-700">
-              {redirectingAction === 'deactivate'
-                ? 'Deactivating account...'
-                : 'Deleting account...'}
-            </span>
-          </div>
-        </div>
-      )}
+      <DeactivationSettings />
     </>
   );
 }

--- a/playlocal/frontend/components/SettingsPage.tsx
+++ b/playlocal/frontend/components/SettingsPage.tsx
@@ -225,7 +225,12 @@ export function SettingsPage() {
 
           {/* Main Content */}
           <div className="lg:col-span-3 space-y-6">
-            {activeTab === 'account' && <AccountSettings user={user} />}
+            {activeTab === 'account' && (
+              <>
+                <AccountSettings />
+                <ProfileSettings user={user} />
+              </>
+            )}
             {activeTab === 'privacy' && <PrivacySettings initialSettings={privacySettings} initialLoading={privacyLoading} initialError={privacyError} onSettingsChange={setPrivacySettings} />}
             {activeTab === 'notifications' && <NotificationSettings />}
             {activeTab === 'security' && <SecuritySettings />}
@@ -236,7 +241,38 @@ export function SettingsPage() {
   );
 }
 
-export function AccountSettings({
+/** AC3: Account route — password change and safety toggles. Exported for /settings/account. */
+export function AccountSettings() {
+  return (
+    <>
+      <PasswordChangeCard />
+
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <h2 className="text-xl text-gray-900 mb-6">Safety & Moderation</h2>
+        <div className="space-y-4">
+          <ToggleSetting
+            label="Require Check-in Confirmation"
+            description="Require manual check-in for all games"
+            value={true}
+          />
+          <ToggleSetting
+            label="Hide Location Until Accepted"
+            description="Don't show exact location until you're accepted to a game"
+            value={true}
+          />
+          <ToggleSetting
+            label="Block Anonymous Users"
+            description="Only allow verified users to contact you"
+            value={false}
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** AC3: Profile fields and preferences. Exported for /settings/profile. */
+export function ProfileSettings({
   user: userFromProps,
 }: {
   user?: {
@@ -253,14 +289,14 @@ export function AccountSettings({
   return (
     <>
       <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="text-xl text-gray-900 mb-6">Account Information</h2>
+        <h2 className="text-xl text-gray-900 mb-6">Profile Information</h2>
         <div className="space-y-6">
           <div>
-            <label htmlFor="displayName" className="block text-gray-700 mb-2">
+            <label htmlFor="profileDisplayName" className="block text-gray-700 mb-2">
               Display Name
             </label>
             <input
-              id="displayName"
+              id="profileDisplayName"
               type="text"
               defaultValue={user?.displayName || ''}
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
@@ -268,11 +304,11 @@ export function AccountSettings({
           </div>
 
           <div>
-            <label htmlFor="email" className="block text-gray-700 mb-2">
+            <label htmlFor="profileEmail" className="block text-gray-700 mb-2">
               Email
             </label>
             <input
-              id="email"
+              id="profileEmail"
               type="email"
               defaultValue={user?.email || ''}
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
@@ -280,11 +316,11 @@ export function AccountSettings({
           </div>
 
           <div>
-            <label htmlFor="phone" className="block text-gray-700 mb-2">
+            <label htmlFor="profilePhone" className="block text-gray-700 mb-2">
               Phone Number
             </label>
             <input
-              id="phone"
+              id="profilePhone"
               type="tel"
               defaultValue={user?.phone || ''}
               placeholder="Enter your phone number"
@@ -293,13 +329,13 @@ export function AccountSettings({
           </div>
 
           <div>
-            <label htmlFor="location" className="block text-gray-700 mb-2">
+            <label htmlFor="profileLocation" className="block text-gray-700 mb-2">
               Location
             </label>
             <div className="relative">
               <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
               <input
-                id="location"
+                id="profileLocation"
                 type="text"
                 defaultValue={user?.location || ''}
                 placeholder="Enter your location"
@@ -309,11 +345,11 @@ export function AccountSettings({
           </div>
 
           <div>
-            <label htmlFor="bio" className="block text-gray-700 mb-2">
+            <label htmlFor="profileBio" className="block text-gray-700 mb-2">
               Bio
             </label>
             <textarea
-              id="bio"
+              id="profileBio"
               rows={4}
               defaultValue={user?.bio || ''}
               placeholder="Tell others about yourself..."
@@ -323,10 +359,16 @@ export function AccountSettings({
         </div>
 
         <div className="mt-6 pt-6 border-t border-gray-200 flex justify-end gap-3">
-          <button className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          <button
+            type="button"
+            className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+          >
             Cancel
           </button>
-          <button className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors">
+          <button
+            type="button"
+            className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors"
+          >
             Save Changes
           </button>
         </div>
@@ -336,11 +378,11 @@ export function AccountSettings({
         <h2 className="text-xl text-gray-900 mb-6">Default Preferences</h2>
         <div className="space-y-4">
           <div>
-            <label htmlFor="defaultIntensity" className="block text-gray-700 mb-2">
+            <label htmlFor="profileDefaultIntensity" className="block text-gray-700 mb-2">
               Default Intensity
             </label>
             <select
-              id="defaultIntensity"
+              id="profileDefaultIntensity"
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
             >
               <option>Low - Casual & Social</option>
@@ -352,20 +394,6 @@ export function AccountSettings({
       </div>
     </>
   );
-}
-
-export function ProfileSettings({
-  user,
-}: {
-  user: {
-    displayName?: string;
-    email?: string;
-    phone?: string;
-    location?: string;
-    bio?: string;
-  } | null;
-}) {
-  return <AccountSettings user={user} />;
 }
 
 // Maps between display labels and backend codes

--- a/playlocal/frontend/components/SettingsPage.tsx
+++ b/playlocal/frontend/components/SettingsPage.tsx
@@ -29,6 +29,51 @@ import { ConfirmAccountActionDialog } from './ConfirmAccountActionDialog';
 import { PasswordChangeCard } from '@/components/PasswordChangeCard';
 import { performLogoutRedirect } from '@/lib/authRedirect';
 
+/** AC6: Error state while loading settings — clear message and retry */
+export function SettingsError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-gray-50 flex flex-col items-center justify-center px-4"
+      role="alert"
+    >
+      <p className="text-gray-800 text-center text-lg font-medium mb-2">
+        Couldn&apos;t load settings
+      </p>
+      <p className="text-gray-600 text-center mb-6 max-w-md">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors font-medium"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+/** AC5: Loading state while fetching settings — full-screen overlay so it’s clearly visible */
+export function SettingsLoading() {
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-gray-50 flex flex-col items-center justify-center"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div
+        className="animate-spin rounded-full h-12 w-12 border-2 border-emerald-600 border-t-transparent mb-4"
+        aria-hidden="true"
+      />
+      <p className="text-gray-600 text-lg font-medium">Loading settings…</p>
+    </div>
+  );
+}
+
 /** AC4: Hub listing links to each settings subpage (each subpage has back navigation). */
 export function SettingsHub() {
   const sections = [

--- a/playlocal/frontend/components/SettingsPage.tsx
+++ b/playlocal/frontend/components/SettingsPage.tsx
@@ -30,13 +30,13 @@ import { PasswordChangeCard } from '@/components/PasswordChangeCard';
 import { performLogoutRedirect } from '@/lib/authRedirect';
 
 /** AC6: Error state while loading settings — clear message and retry */
-export function SettingsError({
-  message,
-  onRetry,
-}: {
-  message: string;
-  onRetry: () => void;
-}) {
+export function SettingsError(
+  props: Readonly<{
+    message: string;
+    onRetry: () => void;
+  }>
+) {
+  const { message, onRetry } = props;
   return (
     <div
       className="fixed inset-0 z-[100] bg-gray-50 flex flex-col items-center justify-center px-4"
@@ -461,8 +461,14 @@ export function PrivacySettings({
         setLocalSettings(data);
         setLocalLoading(false);
       })
-      .catch((err) => {
-        setLocalError(err.message || 'Failed to load privacy settings');
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'string'
+              ? err
+              : 'Failed to load privacy settings';
+        setLocalError(message || 'Failed to load privacy settings');
         setLocalLoading(false);
       });
   }, [controlled]);
@@ -483,8 +489,11 @@ export function PrivacySettings({
 
   const handleSettingsChange = useCallback(
     (next: PrivacySettingsResponse | null) => {
-      if (controlled) onSettingsChange!(next);
-      else setLocalSettings(next);
+      if (controlled) {
+        if (onSettingsChange) onSettingsChange(next);
+      } else {
+        setLocalSettings(next);
+      }
     },
     [controlled, onSettingsChange]
   );

--- a/playlocal/frontend/components/SettingsPage.tsx
+++ b/playlocal/frontend/components/SettingsPage.tsx
@@ -236,7 +236,20 @@ export function SettingsPage() {
   );
 }
 
-function AccountSettings({ user }: { user: any }) {
+export function AccountSettings({
+  user: userFromProps,
+}: {
+  user?: {
+    displayName?: string;
+    email?: string;
+    phone?: string;
+    location?: string;
+    bio?: string;
+  } | null;
+} = {}) {
+  const { user: authUser } = useAuth();
+  const user = userFromProps ?? authUser;
+
   return (
     <>
       <div className="bg-white rounded-xl border border-gray-200 p-6">
@@ -339,6 +352,20 @@ function AccountSettings({ user }: { user: any }) {
       </div>
     </>
   );
+}
+
+export function ProfileSettings({
+  user,
+}: {
+  user: {
+    displayName?: string;
+    email?: string;
+    phone?: string;
+    location?: string;
+    bio?: string;
+  } | null;
+}) {
+  return <AccountSettings user={user} />;
 }
 
 // Maps between display labels and backend codes

--- a/playlocal/frontend/context/AuthContext.tsx
+++ b/playlocal/frontend/context/AuthContext.tsx
@@ -29,6 +29,8 @@ interface AuthContextType {
   ) => Promise<void>;
   logout: () => void;
   refreshUser: () => Promise<void>;
+  /** Retry initial auth check after a failure (e.g. network error). AC6. */
+  retryAuthCheck: () => Promise<void>;
   error: string | null;
 }
 
@@ -51,25 +53,67 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Check for existing token on mount
-  useEffect(() => {
-    const checkAuth = async () => {
-      const token = getAuthToken();
-      if (token) {
-        try {
-          const userData = await authApi.getCurrentUser();
-          setUser(userData);
-        } catch (err) {
-          // Token expired or invalid
+  // Check for existing token on mount (AC6: set error on failure so UI can show retry)
+  const checkAuth = async () => {
+    const token = getAuthToken();
+    if (token) {
+      try {
+        const userData = await authApi.getCurrentUser();
+        setUser(userData);
+        setError(null);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 401) {
           setAuthToken(null);
+          setUser(null);
+          setError(null);
+        } else {
+          setUser(null);
+          setError(
+            err instanceof ApiError
+              ? err.message
+              : 'Something went wrong. Please try again.'
+          );
         }
       }
-      setIsLoading(false);
-    };
+    }
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
     checkAuth();
   }, []);
 
-  const login = async (email: string, password: string, captchaToken?: string): Promise<{ mfaRequired?: boolean }> => {
+  const retryAuthCheck = async () => {
+    setError(null);
+    setIsLoading(true);
+    const token = getAuthToken();
+    if (token) {
+      try {
+        const userData = await authApi.getCurrentUser();
+        setUser(userData);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 401) {
+          setAuthToken(null);
+          setUser(null);
+          setError(null);
+        } else {
+          setUser(null);
+          setError(
+            err instanceof ApiError
+              ? err.message
+              : 'Something went wrong. Please try again.'
+          );
+        }
+      }
+    }
+    setIsLoading(false);
+  };
+
+  const login = async (
+    email: string,
+    password: string,
+    captchaToken?: string
+  ): Promise<{ mfaRequired?: boolean }> => {
     setError(null);
     setIsLoading(true);
     try {
@@ -174,6 +218,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         register,
         logout,
         refreshUser,
+        retryAuthCheck,
         error,
       }}
     >

--- a/playlocal/frontend/lib/api.ts
+++ b/playlocal/frontend/lib/api.ts
@@ -160,6 +160,7 @@ export interface UserDto {
   availability?: string;
   bio?: string;
   location?: string;
+  phone?: string;
   reliabilityScore: number;
   gamesCount: number;
   endorsementsCount?: number; // New field for endorsements count [US-3.3]

--- a/playlocal/frontend/package-lock.json
+++ b/playlocal/frontend/package-lock.json
@@ -5592,16 +5592,18 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
-      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6918,8 +6920,9 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "devOptional": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",

--- a/playlocal/frontend/test/app/settings-layout-and-routes.test.tsx
+++ b/playlocal/frontend/test/app/settings-layout-and-routes.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SettingsLayout from '@/app/settings/layout';
+import SettingsHubPage from '@/app/settings/page';
+import AccountSettingsPage from '@/app/settings/account/page';
+import PrivacySettingsPage from '@/app/settings/privacy/page';
+import NotificationsSettingsPage from '@/app/settings/notifications/page';
+import ProfileSettingsPage from '@/app/settings/profile/page';
+import DeactivationSettingsPage from '@/app/settings/deactivation/page';
+import { useAuth } from '@/context/AuthContext';
+
+jest.mock('@/lib/api', () => {
+  const actual = jest.requireActual<typeof import('@/lib/api')>('@/lib/api');
+  return {
+    ...actual,
+    privacyApi: {
+      ...actual.privacyApi,
+      getSettings: jest.fn().mockResolvedValue({
+        profileVisibility: 'public',
+        skillsVisibility: 'public',
+        historyVisibility: 'public',
+        mediaDefaultVisibility: 'participants',
+        locationVisibilityRule: 'confirmed_only',
+        allowProfileSearch: true,
+      }),
+    },
+  };
+});
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+jest.mock('@/components/PasswordChangeCard', () => ({
+  PasswordChangeCard: () => <div data-testid="password-change-card" />,
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+  usePathname: () => '/settings',
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+function baseAuth(): ReturnType<typeof useAuth> {
+  return {
+    user: {
+      userId: 'u1',
+      email: 'test@example.com',
+      displayName: 'Test User',
+      reliabilityScore: 80,
+      gamesCount: 1,
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    login: jest.fn(),
+    verifyMfa: jest.fn(),
+    register: jest.fn(),
+    logout: jest.fn(),
+    refreshUser: jest.fn(),
+    retryAuthCheck: jest.fn(),
+    error: null,
+  };
+}
+
+describe('SettingsLayout (app/settings/layout)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows SettingsLoading while auth is loading', () => {
+    mockUseAuth.mockReturnValue({
+      ...baseAuth(),
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+
+    render(
+      <SettingsLayout>
+        <p>child</p>
+      </SettingsLayout>
+    );
+
+    expect(screen.getByText('Loading settings…')).toBeInTheDocument();
+  });
+
+  it('shows SettingsError with retry when auth error is set', async () => {
+    const retryAuthCheck = jest.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({
+      ...baseAuth(),
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: 'Session check failed',
+      retryAuthCheck,
+    });
+
+    render(
+      <SettingsLayout>
+        <p>child</p>
+      </SettingsLayout>
+    );
+
+    expect(screen.getByText('Session check failed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(retryAuthCheck).toHaveBeenCalled();
+  });
+
+  it('renders children when authenticated', () => {
+    mockUseAuth.mockReturnValue(baseAuth());
+
+    render(
+      <SettingsLayout>
+        <p>inside-settings</p>
+      </SettingsLayout>
+    );
+
+    expect(screen.getByText('inside-settings')).toBeInTheDocument();
+  });
+});
+
+describe('Settings route pages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue(baseAuth());
+  });
+
+  it('settings/page renders Settings hub', () => {
+    render(<SettingsHubPage />);
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Manage your account and privacy preferences/i)
+    ).toBeInTheDocument();
+  });
+
+  it('account page renders back link and account section', () => {
+    render(<AccountSettingsPage />);
+    expect(screen.getByRole('link', { name: /back to settings/i })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+    expect(screen.getByTestId('password-change-card')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Safety & Moderation' })
+    ).toBeInTheDocument();
+  });
+
+  it('privacy page renders back link and privacy heading', async () => {
+    render(<PrivacySettingsPage />);
+    expect(screen.getByRole('link', { name: /back to settings/i })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+    expect(
+      await screen.findByRole('heading', { name: 'Profile Visibility' })
+    ).toBeInTheDocument();
+  });
+
+  it('notifications page renders back link and notification heading', () => {
+    render(<NotificationsSettingsPage />);
+    expect(screen.getByRole('link', { name: /back to settings/i })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Notification Preferences' })
+    ).toBeInTheDocument();
+  });
+
+  it('profile page renders profile information heading', () => {
+    render(<ProfileSettingsPage />);
+    expect(screen.getByRole('link', { name: /back to settings/i })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Profile Information' })
+    ).toBeInTheDocument();
+  });
+
+  it('deactivation page renders back link and account actions', () => {
+    render(<DeactivationSettingsPage />);
+    expect(screen.getByRole('link', { name: /back to settings/i })).toHaveAttribute(
+      'href',
+      '/settings'
+    );
+    expect(screen.getByText('Deactivate Account')).toBeInTheDocument();
+    expect(screen.getByText('Delete Account')).toBeInTheDocument();
+  });
+});

--- a/playlocal/frontend/test/components/Navigation.test.tsx
+++ b/playlocal/frontend/test/components/Navigation.test.tsx
@@ -1,37 +1,52 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Navigation } from '@/components/Navigation';
 
+const pushMock = jest.fn();
 const performLogoutRedirectMock = jest.fn();
 const openAssistantMock = jest.fn();
 const inferRouteMock = jest.fn(() => ({ context: 'discover' as const }));
-let pathnameMock = '/discover';
-let authStateMock = {
-  user: { displayName: 'Youssef' },
-  isAuthenticated: true,
-  isLoading: false,
-};
+
+/** Mutable so tests can assert /settings active styles and route-driven behavior */
+let mockPathname = '/discover';
 
 jest.mock('next/link', () => {
-  return ({ href, children, ...props }: any) => (
-    <a href={href} {...props}>
+  return ({ href, children, onClick, ...props }: any) => (
+    <a
+      href={href}
+      {...props}
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        onClick?.(e);
+      }}
+    >
       {children}
     </a>
   );
 });
 
 jest.mock('next/navigation', () => ({
-  usePathname: () => pathnameMock,
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: pushMock }),
 }));
 
 jest.mock('@/context/AuthContext', () => ({
-  useAuth: () => authStateMock,
+  useAuth: () => ({
+    user: { displayName: 'Youssef' },
+    isAuthenticated: true,
+    isLoading: false,
+    logout: jest.fn(),
+  }),
 }));
 
-let unreadCountMock = 0;
+jest.mock('@/lib/authRedirect', () => ({
+  performLogoutRedirect: (...args: unknown[]) =>
+    performLogoutRedirectMock(...args),
+}));
+
 jest.mock('@/hooks/useNotifications', () => ({
-  useNotifications: () => ({ unreadCount: unreadCountMock }),
+  useNotifications: () => ({ unreadCount: 0 }),
 }));
 
 jest.mock('@/context/AssistantContext', () => ({
@@ -42,116 +57,75 @@ jest.mock('@/lib/inferAssistantRoute', () => ({
   inferAssistantRoute: (...args: unknown[]) => inferRouteMock(...args),
 }));
 
-jest.mock('@/lib/authRedirect', () => ({
-  performLogoutRedirect: (...args: unknown[]) => performLogoutRedirectMock(...args),
-}));
-
-let isMobileMock = false;
-jest.mock('@/components/ui/use-mobile', () => ({
-  useIsMobile: () => isMobileMock,
-}));
-
 describe('Navigation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    pathnameMock = '/discover';
-    isMobileMock = false;
-    unreadCountMock = 0;
-    authStateMock = {
-      user: { displayName: 'Youssef' },
-      isAuthenticated: true,
-      isLoading: false,
-    };
+    mockPathname = '/discover';
   });
 
-  it('opens assistant from Help button', () => {
+  it('opens assistant from Help button', async () => {
     render(<Navigation />);
-    fireEvent.click(screen.getByRole('button', { name: /open help assistant/i }));
+    const help = await screen.findByRole('button', { name: /open help assistant/i });
+    fireEvent.click(help);
     expect(inferRouteMock).toHaveBeenCalledWith('/discover');
     expect(openAssistantMock).toHaveBeenCalledWith('discover', undefined);
   });
 
-  it('returns nothing on the landing page', () => {
-    pathnameMock = '/';
-
-    const { container } = render(<Navigation />);
-
-    expect(container.firstChild).toBeNull();
-  });
-
-  it('shows loading skeleton while auth is loading', () => {
-    authStateMock = {
-      user: null,
-      isAuthenticated: false,
-      isLoading: true,
-    };
-
-    const { container } = render(<Navigation />);
-
-    expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Sign out')).not.toBeInTheDocument();
-    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
-  });
-
-  it('calls redirect logout helper when sign out is clicked', () => {
+  it('applies active styles to profile menu when pathname is under /settings', async () => {
+    mockPathname = '/settings/privacy';
     render(<Navigation />);
+    const menuBtn = await screen.findByRole('button', { name: /open account menu/i });
+    expect(menuBtn.className).toMatch(/text-emerald-600/);
+  });
 
-    fireEvent.click(screen.getByTitle('Sign out'));
+  it('closes profile menu on mousedown outside', async () => {
+    render(<Navigation />);
+    fireEvent.click(await screen.findByRole('button', { name: /open account menu/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Sign out calls performLogoutRedirect', async () => {
+    render(<Navigation />);
+    fireEvent.click(await screen.findByRole('button', { name: /open account menu/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /sign out/i }));
 
     expect(performLogoutRedirectMock).toHaveBeenCalledWith('/');
   });
 
-  describe('mobile view', () => {
-    beforeEach(() => {
-      isMobileMock = true;
+  it('Settings link points to /settings', async () => {
+    render(<Navigation />);
+    fireEvent.click(await screen.findByRole('button', { name: /open account menu/i }));
+    const settingsLink = screen.getByRole('menuitem', { name: /^settings$/i });
+    expect(settingsLink.getAttribute('href')).toBe('/settings');
+  });
+
+  it('closes menu when Profile link is clicked', async () => {
+    render(<Navigation />);
+    fireEvent.click(await screen.findByRole('button', { name: /open account menu/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /^profile$/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
+  });
 
-    it('shows notification bell and sign out for authenticated user', () => {
-      render(<Navigation />);
-
-      expect(screen.getByTitle('Sign out')).toBeInTheDocument();
-      expect(screen.queryByText('Discover Games')).not.toBeInTheDocument();
+  it('closes menu when Settings link is clicked', async () => {
+    render(<Navigation />);
+    fireEvent.click(await screen.findByRole('button', { name: /open account menu/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /^settings$/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
+  });
 
-    it('calls logout when mobile sign out is clicked', () => {
-      render(<Navigation />);
-
-      fireEvent.click(screen.getByTitle('Sign out'));
-
-      expect(performLogoutRedirectMock).toHaveBeenCalledWith('/');
-    });
-
-    it('shows Sign In link when not authenticated', () => {
-      authStateMock = {
-        user: null as any,
-        isAuthenticated: false,
-        isLoading: false,
-      };
-
-      render(<Navigation />);
-
-      expect(screen.getByText('Sign In')).toBeInTheDocument();
-      expect(screen.queryByTitle('Sign out')).not.toBeInTheDocument();
-    });
-
-    it('shows notification badge when unreadCount > 0', () => {
-      unreadCountMock = 5;
-
-      render(<Navigation />);
-
-      expect(screen.getByText('5')).toBeInTheDocument();
-    });
-
-    it('shows loading skeleton on mobile when auth is loading', () => {
-      authStateMock = {
-        user: null as any,
-        isAuthenticated: false,
-        isLoading: true,
-      };
-
-      const { container } = render(<Navigation />);
-
-      expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
-    });
+  it('renders nothing on landing page', () => {
+    mockPathname = '/';
+    const { container } = render(<Navigation />);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/playlocal/frontend/test/components/ProtectedRoute.test.tsx
+++ b/playlocal/frontend/test/components/ProtectedRoute.test.tsx
@@ -31,9 +31,11 @@ describe('ProtectedRoute', () => {
       isAuthenticated: false,
       isLoading: true,
       login: jest.fn(),
+      verifyMfa: jest.fn(),
       register: jest.fn(),
       logout: jest.fn(),
       refreshUser: jest.fn(),
+      retryAuthCheck: jest.fn(),
       error: null,
     });
 
@@ -53,9 +55,11 @@ describe('ProtectedRoute', () => {
       isAuthenticated: false,
       isLoading: false,
       login: jest.fn(),
+      verifyMfa: jest.fn(),
       register: jest.fn(),
       logout: jest.fn(),
       refreshUser: jest.fn(),
+      retryAuthCheck: jest.fn(),
       error: null,
     });
 
@@ -82,9 +86,11 @@ describe('ProtectedRoute', () => {
       isAuthenticated: true,
       isLoading: false,
       login: jest.fn(),
+      verifyMfa: jest.fn(),
       register: jest.fn(),
       logout: jest.fn(),
       refreshUser: jest.fn(),
+      retryAuthCheck: jest.fn(),
       error: null,
     });
 
@@ -95,5 +101,62 @@ describe('ProtectedRoute', () => {
     );
 
     expect(screen.getByText('Secret content')).toBeInTheDocument();
+  });
+
+  it('renders custom loadingContent when provided', () => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+      login: jest.fn(),
+      verifyMfa: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+      retryAuthCheck: jest.fn(),
+      error: null,
+    });
+
+    render(
+      <ProtectedRoute loadingContent={<span>Custom loading UI</span>}>
+        <div>Secret</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.getByText('Custom loading UI')).toBeInTheDocument();
+  });
+
+  it('renders custom errorContent when auth error and callback provided', async () => {
+    const retryAuthCheck = jest.fn().mockResolvedValue(undefined);
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      login: jest.fn(),
+      verifyMfa: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+      retryAuthCheck,
+      error: 'Boom',
+    });
+
+    render(
+      <ProtectedRoute
+        errorContent={(err, retry) => (
+          <button type="button" onClick={retry}>
+            {err}
+          </button>
+        )}
+      >
+        <div>Secret</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.getByRole('button', { name: 'Boom' })).toBeInTheDocument();
+    screen.getByRole('button', { name: 'Boom' }).click();
+    await waitFor(() => {
+      expect(retryAuthCheck).toHaveBeenCalled();
+    });
   });
 });

--- a/playlocal/frontend/test/components/SettingsPage.test.tsx
+++ b/playlocal/frontend/test/components/SettingsPage.test.tsx
@@ -107,7 +107,12 @@ describe('SettingsPage - Privacy Tab', () => {
     });
 
     const selects = screen.getAllByRole('combobox');
-    expect(selects.length).toBe(1);
+    expect(selects).toHaveLength(5);
+    expect(selects[0]).toHaveValue('Public');
+    expect(selects[1]).toHaveValue('Public');
+    expect(selects[2]).toHaveValue('Friends Only');
+    expect(selects[3]).toHaveValue('Participants');
+    expect(selects[4]).toHaveValue('After Accepted');
   });
 
   it('calls updateSettings when a privacy setting is changed', async () => {

--- a/playlocal/frontend/test/components/SettingsPage.test.tsx
+++ b/playlocal/frontend/test/components/SettingsPage.test.tsx
@@ -426,6 +426,24 @@ describe('Settings hub UI', () => {
         ).toBeInTheDocument();
       });
     });
+
+    it('shows rejected string as error message for standalone load', async () => {
+      mockGetSettings.mockRejectedValue('bad');
+      render(<PrivacySettings />);
+      await waitFor(() => {
+        expect(screen.getByText('bad')).toBeInTheDocument();
+      });
+    });
+
+    it('shows fallback when getSettings rejects a non-Error object', async () => {
+      mockGetSettings.mockRejectedValue({ notAnError: true });
+      render(<PrivacySettings />);
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to load privacy settings')
+        ).toBeInTheDocument();
+      });
+    });
   });
 
   describe('ProfileSettings', () => {

--- a/playlocal/frontend/test/components/SettingsPage.test.tsx
+++ b/playlocal/frontend/test/components/SettingsPage.test.tsx
@@ -63,6 +63,16 @@ jest.mock('@/lib/api', () => ({
   },
 }));
 
+jest.mock('@/components/PasswordChangeCard', () => ({
+  PasswordChangeCard: () => (
+    <div data-testid="password-change-card">
+      <input placeholder="Enter current password" />
+      <input placeholder="Enter new password" />
+      <button type="button">Update Password</button>
+    </div>
+  ),
+}));
+
 jest.mock('@/lib/toast', () => {
   const actual = jest.requireActual('@/lib/toast');
   return {
@@ -393,10 +403,11 @@ describe('Settings hub UI', () => {
   });
 
   describe('AccountSettings', () => {
-    it('renders account information heading', () => {
+    it('renders PasswordChangeCard and Safety & Moderation', () => {
       render(<AccountSettings />);
+      expect(screen.getByTestId('password-change-card')).toBeInTheDocument();
       expect(
-        screen.getByRole('heading', { name: 'Account Information' })
+        screen.getByRole('heading', { name: 'Safety & Moderation' })
       ).toBeInTheDocument();
     });
   });
@@ -418,14 +429,14 @@ describe('Settings hub UI', () => {
   });
 
   describe('ProfileSettings', () => {
-    it('renders profile fields via AccountSettings', () => {
+    it('renders profile information heading and fields', () => {
       render(
         <ProfileSettings
           user={{ displayName: 'Test User', email: 'test@example.com' }}
         />
       );
       expect(
-        screen.getByRole('heading', { name: 'Account Information' })
+        screen.getByRole('heading', { name: 'Profile Information' })
       ).toBeInTheDocument();
     });
   });

--- a/playlocal/frontend/test/components/SettingsPage.test.tsx
+++ b/playlocal/frontend/test/components/SettingsPage.test.tsx
@@ -1,9 +1,36 @@
+import type { ReactNode } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { SettingsPage } from '@/components/SettingsPage';
+import {
+  SettingsPage,
+  SettingsHub,
+  SettingsLoading,
+  SettingsError,
+  AccountSettings,
+  PrivacySettings,
+  ProfileSettings,
+} from '@/components/SettingsPage';
 import { privacyApi, usersApi, authApi } from '@/lib/api';
 import { toast } from '@/lib/toast';
 
 const mockPerformLogoutRedirect = jest.fn();
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: ReactNode;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  },
+}));
 
 jest.mock('@/context/AuthContext', () => ({
   useAuth: () => ({
@@ -20,7 +47,6 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
-// Mock the APIs
 jest.mock('@/lib/api', () => ({
   privacyApi: {
     getSettings: jest.fn(),
@@ -53,7 +79,6 @@ jest.mock('@/lib/authRedirect', () => ({
   performLogoutRedirect: (...args: unknown[]) =>
     mockPerformLogoutRedirect(...args),
 }));
-
 
 const mockGetSettings = privacyApi.getSettings as jest.Mock;
 const mockUpdateSettings = privacyApi.updateSettings as jest.Mock;
@@ -311,5 +336,122 @@ describe('SettingsPage - Security Tab (MFA)', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Disable MFA' })).toBeInTheDocument();
     });
+  });
+});
+
+describe('Settings hub UI', () => {
+  describe('SettingsHub', () => {
+    it('renders Settings heading and description', () => {
+      render(<SettingsHub />);
+      expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+      expect(
+        screen.getByText(/Manage your account and privacy preferences/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders all five section links with correct labels', () => {
+      render(<SettingsHub />);
+      expect(screen.getByText('Account')).toBeInTheDocument();
+      expect(screen.getByText('Privacy / Visibility')).toBeInTheDocument();
+      expect(screen.getByText('Profile')).toBeInTheDocument();
+      expect(screen.getByText('Notifications')).toBeInTheDocument();
+      expect(screen.getByText('Deactivation')).toBeInTheDocument();
+    });
+
+    it('renders section descriptions', () => {
+      render(<SettingsHub />);
+      expect(screen.getByText(/Password & security/i)).toBeInTheDocument();
+      expect(screen.getByText(/Profile and location privacy/i)).toBeInTheDocument();
+      expect(screen.getByText(/Display name, bio, preferences/i)).toBeInTheDocument();
+      expect(screen.getByText(/Game, social & email preferences/i)).toBeInTheDocument();
+      expect(screen.getByText(/Deactivate or delete account/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('SettingsLoading', () => {
+    it('renders loading message', () => {
+      render(<SettingsLoading />);
+      expect(screen.getByText(/Loading settings…/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('SettingsError', () => {
+    it('renders error heading and message', () => {
+      render(<SettingsError message="Network error" onRetry={() => {}} />);
+      expect(screen.getByText(/Couldn't load settings/i)).toBeInTheDocument();
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    it('renders Try again button and calls onRetry when clicked', () => {
+      const onRetry = jest.fn();
+      render(<SettingsError message="Something went wrong" onRetry={onRetry} />);
+      const button = screen.getByRole('button', { name: /Try again/i });
+      expect(button).toBeInTheDocument();
+      fireEvent.click(button);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('AccountSettings', () => {
+    it('renders account information heading', () => {
+      render(<AccountSettings />);
+      expect(
+        screen.getByRole('heading', { name: 'Account Information' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('PrivacySettings', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetSettings.mockResolvedValue(defaultSettings);
+    });
+
+    it('renders profile visibility card heading', async () => {
+      render(<PrivacySettings />);
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Profile Visibility' })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('ProfileSettings', () => {
+    it('renders profile fields via AccountSettings', () => {
+      render(
+        <ProfileSettings
+          user={{ displayName: 'Test User', email: 'test@example.com' }}
+        />
+      );
+      expect(
+        screen.getByRole('heading', { name: 'Account Information' })
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SettingsHub navigation', () => {
+  it('SettingsHub links point to correct settings subpaths', () => {
+    render(<SettingsHub />);
+    const links = screen.getAllByRole('link');
+    const hrefs = links.map((el) => el.getAttribute('href'));
+    expect(hrefs).toContain('/settings/account');
+    expect(hrefs).toContain('/settings/privacy');
+    expect(hrefs).toContain('/settings/profile');
+    expect(hrefs).toContain('/settings/notifications');
+    expect(hrefs).toContain('/settings/deactivation');
+  });
+
+  it('each section link is clickable (has href)', () => {
+    render(<SettingsHub />);
+    const accountLink = screen
+      .getAllByRole('link')
+      .find((el) => el.getAttribute('href') === '/settings/account');
+    expect(accountLink).toBeInTheDocument();
+    const privacyLink = screen
+      .getAllByRole('link')
+      .find((el) => el.getAttribute('href') === '/settings/privacy');
+    expect(privacyLink).toBeInTheDocument();
   });
 });

--- a/playlocal/frontend/test/context/AuthContext.test.tsx
+++ b/playlocal/frontend/test/context/AuthContext.test.tsx
@@ -23,7 +23,6 @@ jest.mock('@/lib/api', () => {
       login: jest.fn(),
       register: jest.fn(),
       logout: jest.fn(),
-      verifyMfa: jest.fn(),
     },
     setAuthToken: jest.fn(),
     getAuthToken: jest.fn(),
@@ -36,7 +35,6 @@ const mockedAuthApi = authApi as unknown as {
   login: jest.Mock;
   register: jest.Mock;
   logout: jest.Mock;
-  verifyMfa: jest.Mock;
 };
 
 const mockedSetAuthToken = setAuthToken as unknown as jest.Mock;
@@ -50,10 +48,10 @@ function TestConsumer() {
     isLoading,
     error,
     login,
-    verifyMfa,
     register,
     logout,
     refreshUser,
+    retryAuthCheck,
   } = useAuth();
 
   return (
@@ -78,8 +76,8 @@ function TestConsumer() {
       <button onClick={() => refreshUser()} type="button">
         doRefresh
       </button>
-      <button onClick={() => verifyMfa('a@b.com', '123456').catch(() => {})} type="button">
-        doVerifyMfa
+      <button onClick={() => retryAuthCheck()} type="button">
+        doRetryAuth
       </button>
     </div>
   );
@@ -159,6 +157,37 @@ describe('AuthContext / AuthProvider', () => {
     expect(screen.getByTestId('userEmail')).toHaveTextContent('');
   });
 
+  it('on mount: token exists but getCurrentUser fails with non-401 ApiError => sets ApiError message', async () => {
+    mockedGetAuthToken.mockReturnValueOnce('token-123');
+    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(
+      new ApiError('Server unavailable', 503)
+    );
+
+    renderWithProvider(<TestConsumer />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('isLoading')).toHaveTextContent('false');
+    });
+
+    expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('false');
+    expect(screen.getByTestId('error')).toHaveTextContent('Server unavailable');
+  });
+
+  it('on mount: token exists but getCurrentUser fails with generic Error => sets generic message', async () => {
+    mockedGetAuthToken.mockReturnValueOnce('token-123');
+    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new Error('network'));
+
+    renderWithProvider(<TestConsumer />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('isLoading')).toHaveTextContent('false');
+    });
+
+    expect(screen.getByTestId('error')).toHaveTextContent(
+      'Something went wrong. Please try again.'
+    );
+  });
+
   it('login success: calls authApi.login, stores token, sets user, clears loading', async () => {
     mockedGetAuthToken.mockReturnValueOnce(null); // mount
     mockedAuthApi.login.mockResolvedValueOnce({
@@ -186,7 +215,6 @@ describe('AuthContext / AuthProvider', () => {
     expect(mockedAuthApi.login).toHaveBeenCalledWith({
       email: 'a@b.com',
       password: 'pw',
-      captchaToken: undefined,
     });
     expect(mockedSetAuthToken).toHaveBeenCalledWith('new-token');
 
@@ -310,7 +338,6 @@ describe('AuthContext / AuthProvider', () => {
       displayName: 'Reg User',
       ageConfirmed: true,
       eulaAccepted: true,
-      captchaToken: undefined,
     });
     expect(mockedSetAuthToken).toHaveBeenCalledWith('reg-token');
 
@@ -433,7 +460,7 @@ describe('AuthContext / AuthProvider', () => {
 
     // refresh: token exists but request fails
     mockedGetAuthToken.mockReturnValueOnce('token-123');
-    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new ApiError('Unauthorized', 401));
+    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new Error('401'));
 
     await act(async () => {
       screen.getByRole('button', { name: 'doRefresh' }).click();
@@ -445,122 +472,6 @@ describe('AuthContext / AuthProvider', () => {
 
     expect(mockedSetAuthToken).toHaveBeenCalledWith(null);
     expect(screen.getByTestId('userEmail')).toHaveTextContent('');
-  });
-
-  it('login with mfaRequired: returns mfaRequired true without setting user', async () => {
-    mockedGetAuthToken.mockReturnValueOnce(null);
-    mockedAuthApi.login.mockResolvedValueOnce({ mfaRequired: true });
-
-    function MfaLoginConsumer() {
-      const { login, isAuthenticated, isLoading } = useAuth();
-      const [mfaNeeded, setMfaNeeded] = React.useState(false);
-      return (
-        <div>
-          <div data-testid="auth">{String(isAuthenticated)}</div>
-          <div data-testid="loading">{String(isLoading)}</div>
-          <div data-testid="mfa">{String(mfaNeeded)}</div>
-          <button
-            type="button"
-            onClick={async () => {
-              const res = await login('a@b.com', 'pw');
-              if (res.mfaRequired) setMfaNeeded(true);
-            }}
-          >
-            run
-          </button>
-        </div>
-      );
-    }
-
-    renderWithProvider(<MfaLoginConsumer />);
-    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
-
-    await act(async () => {
-      screen.getByRole('button', { name: 'run' }).click();
-    });
-
-    expect(screen.getByTestId('mfa')).toHaveTextContent('true');
-    expect(screen.getByTestId('auth')).toHaveTextContent('false');
-    expect(mockedSetAuthToken).not.toHaveBeenCalled();
-  });
-
-  it('verifyMfa success: stores token and sets user', async () => {
-    mockedGetAuthToken.mockReturnValueOnce(null);
-    mockedAuthApi.verifyMfa.mockResolvedValueOnce({
-      token: 'mfa-token',
-      user: { userId: 'u5', email: 'mfa@b.com', displayName: 'MFA', reliabilityScore: 80, gamesCount: 3 },
-    });
-
-    renderWithProvider(<TestConsumer />);
-    await waitFor(() => expect(screen.getByTestId('isLoading')).toHaveTextContent('false'));
-
-    await act(async () => {
-      screen.getByRole('button', { name: 'doVerifyMfa' }).click();
-    });
-
-    expect(mockedAuthApi.verifyMfa).toHaveBeenCalledWith({ email: 'a@b.com', code: '123456' });
-    expect(mockedSetAuthToken).toHaveBeenCalledWith('mfa-token');
-    await waitFor(() => expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('true'));
-    expect(screen.getByTestId('userEmail')).toHaveTextContent('mfa@b.com');
-  });
-
-  it('verifyMfa failure with ApiError: sets error message', async () => {
-    mockedGetAuthToken.mockReturnValueOnce(null);
-    const err = new (ApiError as any)('Invalid MFA code', 401);
-    mockedAuthApi.verifyMfa.mockRejectedValueOnce(err);
-
-    renderWithProvider(<TestConsumer />);
-    await waitFor(() => expect(screen.getByTestId('isLoading')).toHaveTextContent('false'));
-
-    await act(async () => {
-      screen.getByRole('button', { name: 'doVerifyMfa' }).click();
-    });
-
-    await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('Invalid MFA code'));
-    expect(screen.getByTestId('isLoading')).toHaveTextContent('false');
-  });
-
-  it('verifyMfa failure with non-ApiError: sets generic message', async () => {
-    mockedGetAuthToken.mockReturnValueOnce(null);
-    mockedAuthApi.verifyMfa.mockRejectedValueOnce(new Error('network'));
-
-    renderWithProvider(<TestConsumer />);
-    await waitFor(() => expect(screen.getByTestId('isLoading')).toHaveTextContent('false'));
-
-    await act(async () => {
-      screen.getByRole('button', { name: 'doVerifyMfa' }).click();
-    });
-
-    await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('MFA verification failed. Please try again.'));
-  });
-
-  it('register failure with non-ApiError: sets generic message', async () => {
-    mockedGetAuthToken.mockReturnValueOnce(null);
-    mockedAuthApi.register.mockRejectedValueOnce(new Error('network'));
-
-    function RegisterCatcher() {
-      const { error, register } = useAuth();
-      return (
-        <div>
-          <div data-testid="err">{error ?? ''}</div>
-          <button
-            type="button"
-            onClick={async () => {
-              try { await register('r@b.com', 'pw', 'Reg', true, true); } catch {}
-            }}
-          >
-            run
-          </button>
-        </div>
-      );
-    }
-
-    renderWithProvider(<RegisterCatcher />);
-    await act(async () => {
-      screen.getByRole('button', { name: 'run' }).click();
-    });
-
-    await waitFor(() => expect(screen.getByTestId('err')).toHaveTextContent('Registration failed. Please try again.'));
   });
 
   it('refreshUser: no token => does nothing', async () => {
@@ -579,5 +490,120 @@ describe('AuthContext / AuthProvider', () => {
     expect(mockedAuthApi.getCurrentUser).not.toHaveBeenCalled();
     expect(mockedSetAuthToken).not.toHaveBeenCalled();
     expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('false');
+  });
+
+  describe('retryAuthCheck', () => {
+    it('with token: loads user and clears error', async () => {
+      mockedGetAuthToken.mockReturnValueOnce(null);
+      renderWithProvider(<TestConsumer />);
+      await waitFor(() =>
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false')
+      );
+
+      mockedGetAuthToken.mockReturnValue('tok');
+      mockedAuthApi.getCurrentUser.mockResolvedValueOnce({
+        userId: 'u1',
+        email: 'retry@example.com',
+        displayName: 'Retry',
+        reliabilityScore: 80,
+        gamesCount: 1,
+      });
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'doRetryAuth' }).click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('true');
+      });
+      expect(screen.getByTestId('userEmail')).toHaveTextContent('retry@example.com');
+      expect(screen.getByTestId('error')).toHaveTextContent('');
+    });
+
+    it('with token and 401 ApiError: clears token and user', async () => {
+      mockedGetAuthToken.mockReturnValueOnce(null);
+      renderWithProvider(<TestConsumer />);
+      await waitFor(() =>
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false')
+      );
+
+      mockedGetAuthToken.mockReturnValue('tok');
+      mockedAuthApi.getCurrentUser.mockRejectedValueOnce(
+        new ApiError('Unauthorized', 401)
+      );
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'doRetryAuth' }).click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false');
+      });
+      expect(mockedSetAuthToken).toHaveBeenCalledWith(null);
+      expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('false');
+    });
+
+    it('with token and non-401 ApiError: sets error message', async () => {
+      mockedGetAuthToken.mockReturnValueOnce(null);
+      renderWithProvider(<TestConsumer />);
+      await waitFor(() =>
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false')
+      );
+
+      mockedGetAuthToken.mockReturnValue('tok');
+      mockedAuthApi.getCurrentUser.mockRejectedValueOnce(
+        new ApiError('Bad gateway', 502)
+      );
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'doRetryAuth' }).click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error')).toHaveTextContent('Bad gateway');
+      });
+      expect(screen.getByTestId('isAuthenticated')).toHaveTextContent('false');
+    });
+
+    it('with token and generic error: sets generic message', async () => {
+      mockedGetAuthToken.mockReturnValueOnce(null);
+      renderWithProvider(<TestConsumer />);
+      await waitFor(() =>
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false')
+      );
+
+      mockedGetAuthToken.mockReturnValue('tok');
+      mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new Error('boom'));
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'doRetryAuth' }).click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('error')).toHaveTextContent(
+          'Something went wrong. Please try again.'
+        );
+      });
+    });
+
+    it('no token: finishes without calling getCurrentUser', async () => {
+      mockedGetAuthToken.mockReturnValueOnce(null);
+      renderWithProvider(<TestConsumer />);
+      await waitFor(() =>
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false')
+      );
+
+      const callsBefore = mockedAuthApi.getCurrentUser.mock.calls.length;
+      mockedGetAuthToken.mockReturnValue(null);
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'doRetryAuth' }).click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('isLoading')).toHaveTextContent('false');
+      });
+      expect(mockedAuthApi.getCurrentUser.mock.calls.length).toBe(callsBefore);
+    });
   });
 });

--- a/playlocal/frontend/test/context/AuthContext.test.tsx
+++ b/playlocal/frontend/test/context/AuthContext.test.tsx
@@ -140,9 +140,12 @@ describe('AuthContext / AuthProvider', () => {
     expect(mockedSetAuthToken).not.toHaveBeenCalled();
   });
 
-  it('on mount: token exists but getCurrentUser fails => clears token and remains unauthenticated', async () => {
+  it('on mount: token exists but getCurrentUser fails with 401 => clears token and remains unauthenticated', async () => {
     mockedGetAuthToken.mockReturnValueOnce('token-123');
-    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new ApiError('Unauthorized', 401));
+    // Must be ApiError with status 401 — plain Error is treated as retryable (AC6)
+    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(
+      new ApiError('Unauthorized', 401)
+    );
 
     renderWithProvider(<TestConsumer />);
 

--- a/playlocal/frontend/test/context/AuthContext.test.tsx
+++ b/playlocal/frontend/test/context/AuthContext.test.tsx
@@ -142,7 +142,7 @@ describe('AuthContext / AuthProvider', () => {
 
   it('on mount: token exists but getCurrentUser fails => clears token and remains unauthenticated', async () => {
     mockedGetAuthToken.mockReturnValueOnce('token-123');
-    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new Error('401'));
+    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new ApiError('Unauthorized', 401));
 
     renderWithProvider(<TestConsumer />);
 
@@ -430,7 +430,7 @@ describe('AuthContext / AuthProvider', () => {
 
     // refresh: token exists but request fails
     mockedGetAuthToken.mockReturnValueOnce('token-123');
-    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new Error('401'));
+    mockedAuthApi.getCurrentUser.mockRejectedValueOnce(new ApiError('Unauthorized', 401));
 
     await act(async () => {
       screen.getByRole('button', { name: 'doRefresh' }).click();


### PR DESCRIPTION
# Pull Request

Delivers **US-7.8: Settings Hub** on branch **`181-US-78-Settings-Hub-(Overall-Settings-Page-&-Basic-Functionalities)`**: profile/avatar entry to Settings, protected `/settings` routes, hub + section subpages with back navigation, loading and error+retry states, and Jest tests for render + navigation.
Closes #181

## Type of Change

- [ ] Bug fix
- [x] New feature (User Story)
- [x] Task implementation
- [ ] Documentation update
- [ ] Code refactoring
- [x] Unit tests
- [ ] Other (please describe)

## Related Issues

- Implements: **#181** — US-7.8 Settings Hub  

**Details:**  
- Settings uses the existing protected-route pattern with optional loading/error UI.  
- Auth retry path re-runs session load without silently dropping the user into a broken page.  
- Tests lock in hub labels and `/settings/*` hrefs.


## Unit Tests

- [x] Unit tests written
- [x] Code coverage >80%
- [x] Unit tests documented
- [x] All tests passing


## Screenshots
(https://drive.google.com/file/d/12kd5bKq3tPsWQAjVSPNn6WpgTRw84PO7/view?usp=sharing)\

AC#5:  Loading:** DevTools Network → Slow 3G → navigate to Settings → **Loading settings…** 
<img width="906" height="513" alt="Screenshot 2026-03-23 at 7 31 34 PM" src="https://github.com/user-attachments/assets/d73ea401-a4e6-4f35-b0fe-4b910eede1a2" />
