### PR TITLE
273 us 714 monetize website with third party display advertising

### DIFF
--- a/playlocal/frontend/.env.example
+++ b/playlocal/frontend/.env.example
@@ -3,3 +3,19 @@
 # When using Docker: frontend runs in browser, so keep this to reach backend on host.
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=YOUR_API_KEY_HERE
+#
+# Google AdSense (third-party display ads)
+# To show ads on eligible pages:
+# - set NEXT_PUBLIC_ADS_ENABLED=true
+# - set NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID=ca-pub-XXXXXXXXXXXX
+# Optional:
+# - set NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE=true to also show ads on login/reset/game pages
+#   (recommended: leave false to avoid sensitive flows)
+# - Optional manual ad unit: set NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID to the numeric data-ad-slot from AdSense.
+#   Leave empty if you only use auto/page-level ads (no manual unit).
+#   Example: NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID=1234567890
+NEXT_PUBLIC_ADS_ENABLED=false
+NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE=false
+NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID=ca-pub-XXXXXXXXXXXXXXXX
+NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL=true
+NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID=

--- a/playlocal/frontend/app/layout.tsx
+++ b/playlocal/frontend/app/layout.tsx
@@ -21,11 +21,13 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const adsEnabled =
-    process.env.NEXT_PUBLIC_ADS_ENABLED === 'true' ||
-    process.env.NEXT_PUBLIC_ADS_ENABLED === '1';
-  const pubId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID;
+  const rawAdsEnabled = process.env.NEXT_PUBLIC_ADS_ENABLED;
+  const adsEnabled = rawAdsEnabled
+    ? ['1', 'true', 'yes', 'y', 'on'].includes(rawAdsEnabled.toLowerCase())
+    : false;
 
+  const rawPubId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID;
+  const pubId = rawPubId && rawPubId.trim() !== '' ? rawPubId.trim() : undefined;
   return (
     <html lang="en">
       <body className={fontClass}>

--- a/playlocal/frontend/app/layout.tsx
+++ b/playlocal/frontend/app/layout.tsx
@@ -3,6 +3,8 @@ import './globals.css';
 
 import { Providers } from './providers';
 import { Navigation } from '@/components/Navigation';
+import { GoogleAdsenseClient } from '@/components/ads/GoogleAdsenseClient';
+import Script from 'next/script';
 
 // Use system font stack so Docker build does not require network (Google Fonts fetch)
 const fontClass =
@@ -19,11 +21,27 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const adsEnabled =
+    process.env.NEXT_PUBLIC_ADS_ENABLED === 'true' ||
+    process.env.NEXT_PUBLIC_ADS_ENABLED === '1';
+  const pubId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID;
+
   return (
     <html lang="en">
       <body className={fontClass}>
+        {adsEnabled && pubId ? (
+          <Script
+            id="google-adsense-script"
+            async
+            crossOrigin="anonymous"
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(
+              pubId
+            )}`}
+          />
+        ) : null}
         <Providers>
           <Navigation />
+          <GoogleAdsenseClient />
           {children}
         </Providers>
       </body>

--- a/playlocal/frontend/components/ads/GoogleAdsenseClient.tsx
+++ b/playlocal/frontend/components/ads/GoogleAdsenseClient.tsx
@@ -97,6 +97,9 @@ export function GoogleAdsenseClient() {
     !!cfg.pubId &&
     isAdsAllowedForPathname(pathname || '/', cfg.includeSensitive);
 
+  // Reserve UI space / load client script only when something will render or request ads.
+  const hasActiveAdMode = Boolean(cfg.adSlotId || cfg.enablePageLevelAds);
+
   const [scriptReady, setScriptReady] = useState(false);
   const lastAdRequestPathRef = useRef<string | null>(null);
 
@@ -104,7 +107,7 @@ export function GoogleAdsenseClient() {
     let cancelled = false;
 
     async function run() {
-      if (!allowed || !cfg.pubId) return;
+      if (!allowed || !cfg.pubId || !hasActiveAdMode) return;
 
       await ensureAdsenseScript(cfg.pubId);
       if (!cancelled) setScriptReady(true);
@@ -115,11 +118,11 @@ export function GoogleAdsenseClient() {
     return () => {
       cancelled = true;
     };
-  }, [allowed, cfg.pubId]);
+  }, [allowed, cfg.pubId, hasActiveAdMode]);
 
   useEffect(() => {
     // Only push after the script is present and we know the route is allowed.
-    if (!allowed || !scriptReady || !cfg.pubId) return;
+    if (!allowed || !scriptReady || !cfg.pubId || !hasActiveAdMode) return;
 
     // Avoid duplicate requests when React re-runs effects.
     if (lastAdRequestPathRef.current === pathname) return;
@@ -142,9 +145,10 @@ export function GoogleAdsenseClient() {
     cfg.pubId,
     scriptReady,
     pathname,
+    hasActiveAdMode,
   ]);
 
-  if (!allowed || !cfg.pubId) return null;
+  if (!allowed || !cfg.pubId || !hasActiveAdMode) return null;
 
   return (
     <div

--- a/playlocal/frontend/components/ads/GoogleAdsenseClient.tsx
+++ b/playlocal/frontend/components/ads/GoogleAdsenseClient.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { getAdsRuntimeConfig, isAdsAllowedForPathname } from './adsConfig';
+
+declare global {
+  interface Window {
+    adsbygoogle?: any[];
+  }
+}
+
+const ADSENSE_SCRIPT_ID = 'google-adsense-script';
+const DEFAULT_PAGE_LEVEL_MIN_HEIGHT_PX = 120;
+const DEFAULT_SLOT_MIN_HEIGHT_PX = 250;
+
+function ensureAdsenseScript(pubId: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      resolve();
+      return;
+    }
+
+    const existing = document.getElementById(ADSENSE_SCRIPT_ID) as
+      | HTMLScriptElement
+      | null;
+
+    const src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(
+      pubId
+    )}`;
+
+    if (existing) {
+      // Script is already present in the DOM (e.g. injected from SSR layout).
+      // We resolve immediately; queued `adsbygoogle.push(...)` calls will
+      // typically be processed once the script finishes loading.
+      resolve();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = ADSENSE_SCRIPT_ID;
+    script.async = true;
+    script.src = src;
+    script.crossOrigin = 'anonymous';
+
+    script.addEventListener(
+      'load',
+      () => {
+        script.dataset.loaded = 'true';
+        resolve();
+      },
+      { once: true }
+    );
+
+    script.addEventListener(
+      'error',
+      () => {
+        // Never block the page due to a failed third-party script.
+        resolve();
+      },
+      { once: true }
+    );
+
+    document.head.appendChild(script);
+  });
+}
+
+function pushPageLevelAds(pubId: string) {
+  // Standard "page-level / auto" snippet pattern.
+  try {
+    window.adsbygoogle = window.adsbygoogle || [];
+    window.adsbygoogle.push({
+      google_ad_client: pubId,
+      enable_page_level_ads: true,
+    });
+  } catch {
+    // Swallow errors to avoid breaking UX.
+  }
+}
+
+function pushAdIns() {
+  // Standard manual ad slot push after `<ins class="adsbygoogle" .../>`
+  // is present in the DOM.
+  try {
+    window.adsbygoogle = window.adsbygoogle || [];
+    window.adsbygoogle.push({});
+  } catch {
+    // Swallow errors to avoid breaking UX.
+  }
+}
+
+export function GoogleAdsenseClient() {
+  const pathname = usePathname();
+  const cfg = getAdsRuntimeConfig();
+  const allowed =
+    !!cfg.enabled &&
+    !!cfg.pubId &&
+    isAdsAllowedForPathname(pathname || '/', cfg.includeSensitive);
+
+  const [scriptReady, setScriptReady] = useState(false);
+  const lastAdRequestPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      if (!allowed || !cfg.pubId) return;
+
+      await ensureAdsenseScript(cfg.pubId);
+      if (!cancelled) setScriptReady(true);
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allowed, cfg.pubId]);
+
+  useEffect(() => {
+    // Only push after the script is present and we know the route is allowed.
+    if (!allowed || !scriptReady || !cfg.pubId) return;
+
+    // Avoid duplicate requests when React re-runs effects.
+    if (lastAdRequestPathRef.current === pathname) return;
+
+    if (cfg.adSlotId) {
+      pushAdIns();
+      lastAdRequestPathRef.current = pathname || null;
+      return;
+    }
+
+    // If no explicit ad slot id is configured, rely on page-level ads.
+    if (cfg.enablePageLevelAds) {
+      pushPageLevelAds(cfg.pubId);
+      lastAdRequestPathRef.current = pathname || null;
+    }
+  }, [
+    allowed,
+    cfg.adSlotId,
+    cfg.enablePageLevelAds,
+    cfg.pubId,
+    scriptReady,
+    pathname,
+  ]);
+
+  if (!allowed || !cfg.pubId) return null;
+
+  return (
+    <div
+      className="w-full flex justify-center px-4"
+      aria-hidden="true"
+      style={{ minHeight: cfg.adSlotId ? DEFAULT_SLOT_MIN_HEIGHT_PX : DEFAULT_PAGE_LEVEL_MIN_HEIGHT_PX }}
+    >
+      {cfg.adSlotId ? (
+        <div className="w-full max-w-4xl">
+          <ins
+            key={pathname}
+            className="adsbygoogle"
+            style={{ display: 'block' }}
+            data-ad-client={cfg.pubId}
+            data-ad-slot={cfg.adSlotId}
+            data-ad-format="auto"
+            data-full-width-responsive="true"
+          />
+        </div>
+      ) : (
+        <div className="w-full max-w-4xl" />
+      )}
+    </div>
+  );
+}
+

--- a/playlocal/frontend/components/ads/adsConfig.ts
+++ b/playlocal/frontend/components/ads/adsConfig.ts
@@ -1,0 +1,60 @@
+export type AdsRuntimeConfig = {
+  enabled: boolean;
+  includeSensitive: boolean;
+  enablePageLevelAds: boolean;
+  pubId: string | null;
+  adSlotId: string | null;
+};
+
+function parseBooleanEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  return ['true', '1', 'yes', 'y', 'on'].includes(value.toLowerCase());
+}
+
+export function getAdsRuntimeConfig(): AdsRuntimeConfig {
+  const enabled = parseBooleanEnv(process.env.NEXT_PUBLIC_ADS_ENABLED);
+  const includeSensitive = parseBooleanEnv(
+    process.env.NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE
+  );
+  const enablePageLevelAds = parseBooleanEnv(
+    process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL
+  );
+
+  const pubId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID || null;
+  const adSlotId = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID || null;
+
+  return {
+    enabled,
+    includeSensitive,
+    enablePageLevelAds,
+    pubId: pubId && pubId.trim().length > 0 ? pubId : null,
+    adSlotId: adSlotId && adSlotId.trim().length > 0 ? adSlotId : null,
+  };
+}
+
+// Restricted/sensitive pages where ads should not appear.
+// Keep this list strict by default; you can override via `NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE=true`.
+const RESTRICTED_ROUTE_PREFIXES: string[] = [
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/reset-password',
+  '/games/create',
+  '/rsvpRoster/',
+  '/profile/edit',
+  '/notifications',
+  '/settings',
+];
+
+export function isAdsAllowedForPathname(
+  pathname: string,
+  includeSensitive: boolean
+): boolean {
+  if (includeSensitive) return true;
+
+  return !RESTRICTED_ROUTE_PREFIXES.some((prefix) => {
+    if (prefix.endsWith('/')) return pathname.startsWith(prefix);
+    return pathname === prefix || pathname.startsWith(prefix);
+  });
+}
+

--- a/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
+++ b/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { GoogleAdsenseClient } from '@/components/ads/GoogleAdsenseClient';
+
+const mockPathname = jest.fn(() => '/discover');
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}));
+
+describe('GoogleAdsenseClient', () => {
+  const originalEnv = process.env;
+
+  function ensureAdsenseScriptStubInDom() {
+    if (!document.getElementById('google-adsense-script')) {
+      const s = document.createElement('script');
+      s.id = 'google-adsense-script';
+      document.head.appendChild(s);
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPathname.mockReturnValue('/discover');
+    process.env = { ...originalEnv };
+    document.head.querySelectorAll('#google-adsense-script').forEach((n) => n.remove());
+    window.adsbygoogle = undefined;
+    ensureAdsenseScriptStubInDom();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('renders nothing when ads are disabled', () => {
+    delete process.env.NEXT_PUBLIC_ADS_ENABLED;
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-test';
+    const { container } = render(<GoogleAdsenseClient />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when publisher id is missing', () => {
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID;
+    const { container } = render(<GoogleAdsenseClient />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing on restricted pathname when includeSensitive is false', () => {
+    mockPathname.mockReturnValue('/login');
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-test';
+    process.env.NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE = '';
+    const { container } = render(<GoogleAdsenseClient />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders ad wrapper on allowed path when enabled and pushes page-level ads', async () => {
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-test';
+    process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL = 'true';
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID;
+
+    const pushes: unknown[] = [];
+    window.adsbygoogle = [];
+    window.adsbygoogle.push = jest.fn((...args: unknown[]) => {
+      pushes.push(args[0]);
+      return 0;
+    });
+
+    render(<GoogleAdsenseClient />);
+
+    await waitFor(() => {
+      expect(window.adsbygoogle?.push).toHaveBeenCalled();
+    });
+
+    expect(pushes.some((p) => (p as { google_ad_client?: string })?.google_ad_client === 'ca-pub-test')).toBe(true);
+    expect(pushes.some((p) => (p as { enable_page_level_ads?: boolean })?.enable_page_level_ads)).toBe(true);
+
+    const wrapper = document.querySelector('[aria-hidden="true"].w-full.flex');
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  it('renders ins.adsbygoogle when slot id is set and pushes empty object', async () => {
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-test';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID = '1234567890';
+
+    window.adsbygoogle = [];
+    window.adsbygoogle.push = jest.fn(() => 0);
+
+    render(<GoogleAdsenseClient />);
+
+    await waitFor(() => {
+      expect(document.querySelector('ins.adsbygoogle')).toBeInTheDocument();
+    });
+    expect(document.querySelector('ins')?.getAttribute('data-ad-slot')).toBe('1234567890');
+
+    await waitFor(() => {
+      expect(window.adsbygoogle?.push).toHaveBeenCalled();
+    });
+    expect(window.adsbygoogle?.push).toHaveBeenCalledWith({});
+  });
+
+  it('injects ads script when none exists and completes after load event', async () => {
+    document.head.querySelectorAll('#google-adsense-script').forEach((n) => n.remove());
+
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-dynamic';
+    process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL = 'true';
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID;
+
+    window.adsbygoogle = [];
+    window.adsbygoogle.push = jest.fn(() => 0);
+
+    render(<GoogleAdsenseClient />);
+
+    let script: HTMLScriptElement;
+    await waitFor(() => {
+      const el = document.getElementById('google-adsense-script');
+      expect(el).not.toBeNull();
+      expect((el as HTMLScriptElement).src || '').toContain(
+        'pagead2.googlesyndication.com'
+      );
+      expect((el as HTMLScriptElement).src || '').toContain('ca-pub-dynamic');
+      script = el as HTMLScriptElement;
+    });
+
+    await act(async () => {
+      script.dispatchEvent(new Event('load'));
+    });
+
+    await waitFor(() => {
+      expect(window.adsbygoogle?.push).toHaveBeenCalled();
+    });
+  });
+
+  it('injects ads script when none exists and completes after error event', async () => {
+    document.head.querySelectorAll('#google-adsense-script').forEach((n) => n.remove());
+
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-err';
+    process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL = 'true';
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID;
+
+    window.adsbygoogle = [];
+    window.adsbygoogle.push = jest.fn(() => 0);
+
+    render(<GoogleAdsenseClient />);
+
+    const script = await waitFor(() =>
+      document.getElementById('google-adsense-script') as HTMLScriptElement
+    );
+
+    await act(async () => {
+      script.dispatchEvent(new Event('error'));
+    });
+
+    await waitFor(() => {
+      expect(window.adsbygoogle?.push).toHaveBeenCalled();
+    });
+  });
+
+  it('does not push page-level when enablePageLevelAds is false and no slot', async () => {
+    process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+    process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-test';
+    process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL = 'false';
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID;
+
+    window.adsbygoogle = [];
+    window.adsbygoogle.push = jest.fn(() => 0);
+
+    render(<GoogleAdsenseClient />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(window.adsbygoogle?.push).not.toHaveBeenCalled();
+    const wrapper = document.querySelector('[aria-hidden="true"].w-full.flex');
+    expect(wrapper).toBeInTheDocument();
+  });
+});

--- a/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
+++ b/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { GoogleAdsenseClient } from '@/components/ads/GoogleAdsenseClient';
 
@@ -78,7 +78,7 @@ describe('GoogleAdsenseClient', () => {
     expect(pushes.some((p) => (p as { google_ad_client?: string })?.google_ad_client === 'ca-pub-test')).toBe(true);
     expect(pushes.some((p) => (p as { enable_page_level_ads?: boolean })?.enable_page_level_ads)).toBe(true);
 
-    const wrapper = document.querySelector('[aria-hidden="true"].w-full.flex');
+    const wrapper = document.querySelector('[aria-hidden="true"]');
     expect(wrapper).toBeInTheDocument();
   });
 

--- a/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
+++ b/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
@@ -149,9 +149,11 @@ describe('GoogleAdsenseClient', () => {
 
     render(<GoogleAdsenseClient />);
 
-    const script = await waitFor(() =>
-      document.getElementById('google-adsense-script') as HTMLScriptElement
-    );
+    const script = (await waitFor(() => {
+      const el = document.getElementById('google-adsense-script');
+      expect(el).not.toBeNull();
+      return el;
+    })) as HTMLScriptElement;
 
     await act(async () => {
       script.dispatchEvent(new Event('error'));

--- a/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
+++ b/playlocal/frontend/test/components/ads/GoogleAdsenseClient.test.tsx
@@ -162,7 +162,7 @@ describe('GoogleAdsenseClient', () => {
     });
   });
 
-  it('does not push page-level when enablePageLevelAds is false and no slot', async () => {
+  it('renders nothing and does not push when no slot and page-level ads disabled', async () => {
     process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
     process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-test';
     process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL = 'false';
@@ -171,14 +171,13 @@ describe('GoogleAdsenseClient', () => {
     window.adsbygoogle = [];
     window.adsbygoogle.push = jest.fn(() => 0);
 
-    render(<GoogleAdsenseClient />);
+    const { container } = render(<GoogleAdsenseClient />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));
     });
 
     expect(window.adsbygoogle?.push).not.toHaveBeenCalled();
-    const wrapper = document.querySelector('[aria-hidden="true"].w-full.flex');
-    expect(wrapper).toBeInTheDocument();
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/playlocal/frontend/test/components/ads/adsConfig.test.ts
+++ b/playlocal/frontend/test/components/ads/adsConfig.test.ts
@@ -1,0 +1,84 @@
+import {
+  getAdsRuntimeConfig,
+  isAdsAllowedForPathname,
+} from '@/components/ads/adsConfig';
+
+describe('adsConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_ADS_ENABLED;
+    delete process.env.NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE;
+    delete process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL;
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID;
+    delete process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getAdsRuntimeConfig', () => {
+    it('returns disabled when NEXT_PUBLIC_ADS_ENABLED is unset', () => {
+      process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = 'ca-pub-123';
+      const cfg = getAdsRuntimeConfig();
+      expect(cfg.enabled).toBe(false);
+      expect(cfg.pubId).toBe('ca-pub-123');
+    });
+
+    it('parses NEXT_PUBLIC_ADS_ENABLED truthy variants', () => {
+      for (const v of ['true', '1', 'yes', 'on', 'Y']) {
+        process.env.NEXT_PUBLIC_ADS_ENABLED = v;
+        expect(getAdsRuntimeConfig().enabled).toBe(true);
+      }
+    });
+
+    it('trims empty pubId and slot to null', () => {
+      process.env.NEXT_PUBLIC_ADS_ENABLED = 'true';
+      process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID = '   ';
+      process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID = '\t';
+      const cfg = getAdsRuntimeConfig();
+      expect(cfg.pubId).toBeNull();
+      expect(cfg.adSlotId).toBeNull();
+    });
+
+    it('returns includeSensitive and enablePageLevelAds from env', () => {
+      process.env.NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE = 'true';
+      process.env.NEXT_PUBLIC_ADS_ENABLE_PAGE_LEVEL = '1';
+      const cfg = getAdsRuntimeConfig();
+      expect(cfg.includeSensitive).toBe(true);
+      expect(cfg.enablePageLevelAds).toBe(true);
+    });
+  });
+
+  describe('isAdsAllowedForPathname', () => {
+    it('allows all paths when includeSensitive is true', () => {
+      expect(isAdsAllowedForPathname('/login', true)).toBe(true);
+      expect(isAdsAllowedForPathname('/register', true)).toBe(true);
+    });
+
+    it('blocks known restricted routes when includeSensitive is false', () => {
+      expect(isAdsAllowedForPathname('/login', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/register', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/forgot-password', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/reset-password/new', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/games/create', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/rsvpRoster/abc', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/profile/edit', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/notifications', false)).toBe(false);
+      expect(isAdsAllowedForPathname('/settings', false)).toBe(false);
+    });
+
+    it('allows discover and public browsing routes', () => {
+      expect(isAdsAllowedForPathname('/discover', false)).toBe(true);
+      expect(isAdsAllowedForPathname('/', false)).toBe(true);
+      expect(isAdsAllowedForPathname('/calendar', false)).toBe(true);
+    });
+
+    it('allows game detail paths that are not in restricted list', () => {
+      expect(isAdsAllowedForPathname('/games/xyz', false)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

PR-US-7.14: Integrate Google AdSense (config + gated placements + tests)

## Description

Adds Google AdSense integration to the Next.js frontend: global script in root layout, client-side initialization with route-based gating for sensitive pages, env-based feature flags (`NEXT_PUBLIC_ADS_*`), optional manual ad unit via `NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID`, and Jest tests for `adsConfig` and `GoogleAdsenseClient`. Updates `.env.example` with documented variables. 

Closes #273

## Type of Change

- [ ] Bug fix
- [x] New feature (User Story)
- [ ] Task implementation
- [ ] Documentation update
- [ ] Code refactoring
- [x] Unit tests
- [ ] Other (please describe)

## Related Issues

- Implements: #273 (US-7.14: Monetize website with third-party display advertising)

## Requirements Reference [Mandatory for User Stories]

**Requirement Reference:** US-7.14 / EPIC 7 — third-party ad network integration; ads only on approved placements; excluded from sensitive flows; responsive; owner-configurable enable/disable; no major layout/perf regression; provider policy alignment.

**Justification:** AdSense script is loaded from env when `NEXT_PUBLIC_ADS_ENABLED=true` and publisher ID is set. `GoogleAdsenseClient` and `adsConfig` restrict routes (login, register, password reset, game create, RSVP roster, profile edit, notifications, settings, etc.) unless `NEXT_PUBLIC_ADS_INCLUDE_SENSITIVE=true`. Page-level (automatically placed by adsense) vs manual slot (customized own ad slots ) is configurable. `.env.example` documents configuration for deploys and local dev.

## Risk Mitigation [Mandatory for User Stories]

**Associated Risks:** Ads on auth/sensitive pages; layout shift (CLS); duplicate ad requests; invalid AdSense configuration; committing secrets; AdSense policy compliance.

**Mitigation Strategy:** Address in code and tests; remaining compliance owned by ops and AdSense account settings.

**Details:**

- **Sensitive flows:** Default denylist in `adsConfig`; optional override via env (documented).
- **CLS:** Reserved min-height on ad wrapper; script loading aligned with Next.js layout patterns.
- **Duplicate pushes:** Guarded `push` behavior covered by tests.
- **Secrets:** Placeholders only in `.env.example`; real IDs in hosting env or local `.env.local`.
- **Policy:** Does not replace AdSense site review, ads.txt, or region-specific consent where required - stakeholder responsibility.

## Technical Requirements

- Code follows project frontend standards (App Router, client component for ad logic).
- No architecture diagram update required for this incremental change.

## Unit Tests

**Unit Test Status:** Completed

**Test Documentation:** See `playlocal/frontend/test/components/ads/` (add wiki link if your team maintains one).

- [x] Unit tests written
- [x] Code coverage >80% for ad components (`npm test -- test/components/ads/ --coverage`)
- [ ] Unit tests documented
- [x] All tests passing

## Related Links

**Architecture Diagrams:** N/A

## Customer Signoff

- [x] Requirements reviewed with customer/stakeholder
- [ ] Acceptance criteria approved
- [ ] Customer signoff received

## Definition of Done

- [x] Code implemented and follows standards
- [x] Risk mitigation addressed
- [x] Documentation updated (`.env.example`)
- [ ] Story tagged in git when completed
- [ ] PR reviewed and risks audited

## Screenshots


## Additional Notes

**Deploy:** Set `NEXT_PUBLIC_ADS_ENABLED=true`, `NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID=ca-pub-…`, and optionally `NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID` for manual units. 