### PR TITLE
FIX: Move Google AdSense script to head and set loading strategy

### DIFF
--- a/playlocal/frontend/app/layout.tsx
+++ b/playlocal/frontend/app/layout.tsx
@@ -30,17 +30,20 @@ export default function RootLayout({
   const pubId = rawPubId && rawPubId.trim() !== '' ? rawPubId.trim() : undefined;
   return (
     <html lang="en">
-      <body className={fontClass}>
+      <head>
         {adsEnabled && pubId ? (
           <Script
             id="google-adsense-script"
             async
-            crossOrigin="anonymous"
             src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(
               pubId
             )}`}
+            crossOrigin="anonymous"  // Required for CORS when loading external scripts
+            strategy="afterInteractive" // Load script after the page becomes interactive
           />
         ) : null}
+      </head>
+      <body className={fontClass}>
         <Providers>
           <Navigation />
           <GoogleAdsenseClient />


### PR DESCRIPTION
# Pull Request

FIX -- PR-US-7.14: Load AdSense script in <head> with afterInteractive

## Description

FIX: Google Adsense crawler was unable to verify the site. To fix this: Moves the global Google AdSense `<Script>` from `<body>` into `<head>` and sets `strategy="afterInteractive"` so the publisher script loads after the page is interactive, matching common Next.js + AdSense docs guidance.

Closes #273

## Type of Change

- [ ] Bug fix
- [ ] New feature (User Story)
- [x] Task implementation
- [ ] Documentation update
- [x] Code refactoring
- [ ] Unit tests
- [ ] Other (please describe)

## Related Issues

- Fixes: #273 
- Related to: #273

## Requirements Reference [Mandatory for User Stories]

**Requirement Reference:** US-7.14 - third-party ad integration; site owner can configure ads; implementation does not break layout/UX where possible.

**Justification:** Global AdSense script is now injected in `<head>` (recommended placement for verification and consistency). Loading strategy is explicit (`afterInteractive`) to reduce impact on initial render.

## Risk Mitigation [Mandatory for User Stories]

**Associated Risks:** Script load order / duplicate script tags; verification/crawler expectations; minor perf impact.

**Mitigation Strategy:** Fix now (in code).

## Technical Requirements

- [x] Follows existing Next.js App Router patterns
- [x] No architecture diagram update required

## Unit Tests

**Unit Test Status:** N/A for this change (layout-only relocation)

**Test Documentation:** N/A

- [ ] Unit tests written
- [ ] Code coverage >80%
- [ ] Unit tests documented
- [x] All tests passing _(run locally / CI as usual)_

## Related Links

**Architecture Diagrams:** N/A

## Customer Signoff

- [ ] Requirements reviewed with customer/stakeholder
- [ ] Acceptance criteria approved
- [ ] Customer signoff received

## Definition of Done

- [x] Code implemented and follows standards
- [x] Risk mitigation addressed (see above)
- [ ] Documentation updated _(optional: note in README/wiki if you document env vars)_
- [ ] Story tagged in git when completed
- [ ] PR reviewed and risks audited

## Screenshots

## Additional Notes

**Deployment same as before:** Set `NEXT_PUBLIC_ADS_ENABLED=true`, `NEXT_PUBLIC_GOOGLE_ADSENSE_PUB_ID=ca-pub-…`, and optionally `NEXT_PUBLIC_GOOGLE_ADSENSE_AD_SLOT_ID` for manual units.
