### PR TITLE
BUG FIX: 350 bug deployment discover games show games that return nothing instead of not displaying

### DIFF
--- a/playlocal/backend/src/main/java/com/backend/playlocal/service/GameService.java
+++ b/playlocal/backend/src/main/java/com/backend/playlocal/service/GameService.java
@@ -746,7 +746,10 @@ public class GameService {
 
         /**
          * Get game roster. US-2.4
+         * Must run in a transaction so lazy {@link User} on participations (and organizer on
+         * {@link Game}) can load when {@code open-in-view} is false (e.g. prod).
          */
+        @Transactional(readOnly = true)
         public GameDto.RosterResponse getRoster(UUID gameId, UUID requestingUserId) {
                 Game game = gameRepository.findById(gameId)
                                 .orElseThrow(() -> new ResourceNotFoundException("Game not found"));


### PR DESCRIPTION
Symptoms observed (browser / Render):
- GET .../api/v1/games/{gameId}/roster → 500, JSON "An unexpected error occurred"
- Frontend: ApiError after Promise.all(getById, getRoster); game page showed "Game Not Found"
- Render log: GlobalExceptionHandler "Unhandled exception occurred"
- Root: org.hibernate.LazyInitializationException - could not initialize proxy
  [User#...] - no Session at GameService.mapToParticipantDto (...getDisplayName)

Cause: participations load with lazy User; prod has spring.jpa.open-in-view=false and
getRoster had no transaction, so the Session closed before mapping touched getUser().

Fix: @Transactional(readOnly = true) on GameService.getRoster so lazy associations
initialize in the same persistence context.

Fixes #350

Screenshot:
<img width="546" height="1001" alt="2026-03-31_01h44_29" src="https://github.com/user-attachments/assets/e50f9b09-0ec6-4ac9-a7e3-73bc3078970a" />
