### PR TITLE
351 3 bug deployment  create and view game workflow

### DIFF
--- a/playlocal/frontend/components/CreateGame.tsx
+++ b/playlocal/frontend/components/CreateGame.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   MapPin,
@@ -78,6 +78,9 @@ export function CreateGame() {
   ];
 
   const [isSubmittingCooldown, setIsSubmittingCooldown] = useState(false);
+  const createRequestInFlightRef = useRef(false);
+  const createSucceededRef = useRef(false);
+  const [hasCreateSucceeded, setHasCreateSucceeded] = useState(false);
 
   // US-4.2: Fetch available tags on mount
   useEffect(() => {
@@ -265,6 +268,15 @@ export function CreateGame() {
       return;
     }
 
+    // Ignore duplicate submits while a create request is already in flight.
+    if (
+      createRequestInFlightRef.current ||
+      createSucceededRef.current ||
+      isCreating
+    ) {
+      return;
+    }
+
     if (!isAuthenticated) {
       navigate.push('/login');
       return;
@@ -281,6 +293,8 @@ export function CreateGame() {
     }
 
     try {
+      createRequestInFlightRef.current = true;
+
       // Combine date and time into ISO string
       const startDateTime = `${formData.date}T${formData.startTime}:00`;
       const endDateTime = formData.endTime
@@ -318,12 +332,16 @@ export function CreateGame() {
           : undefined,
       });
 
+      createSucceededRef.current = true;
+      setHasCreateSucceeded(true);
       toast.success('Game created');
       navigate.push(`/games/${game.gameId}`);
     } catch (err: any) {
       const errorMessage = getActionableErrorMessage(err, 'create game');
       setError(errorMessage);
       toast.error(errorMessage);
+    } finally {
+      createRequestInFlightRef.current = false;
     }
   };
 
@@ -1069,9 +1087,14 @@ export function CreateGame() {
               ) : (
                 <button
                   type="submit"
-                  className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors"
+                  disabled={isCreating || hasCreateSucceeded}
+                  className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:bg-emerald-400 disabled:cursor-not-allowed transition-colors"
                 >
-                  Create Game
+                  {hasCreateSucceeded
+                    ? 'Redirecting...'
+                    : isCreating
+                    ? 'Creating...'
+                    : 'Create Game'}
                 </button>
               )}
             </div>

--- a/playlocal/frontend/components/CreateGame.tsx
+++ b/playlocal/frontend/components/CreateGame.tsx
@@ -1149,32 +1149,6 @@ function SummaryRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-// Helper for step validation
-function isValidStep(step: number, formData: any): boolean {
-  if (step === 1) {
-    return !!(
-      formData.title &&
-      formData.sport &&
-      formData.location &&
-      formData.date &&
-      formData.indoor &&
-      formData.startTime &&
-      formData.endTime
-    );
-  }
-  if (step === 2) {
-    return !!(
-      formData.minPlayers &&
-      formData.maxPlayers &&
-      Number.parseInt(formData.maxPlayers, 10) >=
-        Number.parseInt(formData.minPlayers, 10) &&
-      formData.skillLevel &&
-      formData.intensity
-    );
-  }
-  return true;
-}
-
 // Time Select Component
 function TimeSelect({
   value,

--- a/playlocal/frontend/hooks/useGames.ts
+++ b/playlocal/frontend/hooks/useGames.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   gamesApi,
   GameResponse,
@@ -220,22 +220,35 @@ export function useGame(gameId: string | undefined) {
 export function useCreateGame() {
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const inFlightCreateRef = useRef<
+    ReturnType<typeof gamesApi.create> | null
+  >(null);
 
   const createGame = async (data: Parameters<typeof gamesApi.create>[0]) => {
+    if (inFlightCreateRef.current) {
+      return inFlightCreateRef.current;
+    }
+
     setIsCreating(true);
     setError(null);
-    try {
-      if (!gamesApi || typeof gamesApi.create !== 'function') {
-        throw new Error('gamesApi.create is not available');
+    const createPromise = (async () => {
+      try {
+        if (!gamesApi || typeof gamesApi.create !== 'function') {
+          throw new Error('gamesApi.create is not available');
+        }
+        const game = await gamesApi.create(data);
+        return game;
+      } catch (err: any) {
+        setError(err.message || 'Failed to create game');
+        throw err;
+      } finally {
+        inFlightCreateRef.current = null;
+        setIsCreating(false);
       }
-      const game = await gamesApi.create(data);
-      return game;
-    } catch (err: any) {
-      setError(err.message || 'Failed to create game');
-      throw err;
-    } finally {
-      setIsCreating(false);
-    }
+    })();
+
+    inFlightCreateRef.current = createPromise;
+    return createPromise;
   };
 
   return { createGame, isCreating, error };

--- a/playlocal/frontend/test/components/CreateGame.test.tsx
+++ b/playlocal/frontend/test/components/CreateGame.test.tsx
@@ -9,7 +9,7 @@ import {
   within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { CreateGame, isValidStep } from '@/components/CreateGame';
+import { CreateGame } from '@/components/CreateGame';
 import { toast } from '@/lib/toast';
 
 // --------------------
@@ -325,6 +325,132 @@ describe('CreateGame', () => {
     expect(screen.getByText(/basic information/i)).toBeInTheDocument();
   });
 
+  it('validates step 1: sport is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await fillStep1Valid({ sport: '' });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select a sport/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('validates step 1: location is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await fillStep1Valid({ location: '' });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please enter a location/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('validates step 1: date is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await fillStep1Valid({ date: '' });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select a date/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('validates step 1: location type is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await fillStep1Valid({ indoor: '' });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select location type/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('validates step 1: start time is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await fillStep1Valid({ start: '' });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select a start time/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('validates step 1: end time is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await fillStep1Valid({ end: '' });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select an end time/i)
+    ).not.toHaveLength(0);
+  });
+
   it('shows error when start time is in the past for today', async () => {
     // Set system time to late evening so any morning time is definitely in the past
     jest.setSystemTime(new Date('2026-02-09T23:00:00.000Z'));
@@ -367,7 +493,7 @@ describe('CreateGame', () => {
 
     render(<CreateGame />);
 
-    await fillStep1Valid({ start: '11:00', end: '11:00' });
+    await fillStep1Valid({ date: '2030-01-01', start: '11:00', end: '11:00' });
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(screen.getByText(/basic information/i)).toBeInTheDocument();
   });
@@ -557,6 +683,37 @@ describe('CreateGame', () => {
     ).not.toHaveLength(0);
   });
 
+  it('step 2 validates player counts must be numbers (forced invalid numeric input)', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+
+    await goToStep2();
+    const minPlayersInput = screen.getByPlaceholderText('e.g., 6') as HTMLInputElement;
+    const maxPlayersInput = screen.getByPlaceholderText('e.g., 10') as HTMLInputElement;
+
+    Object.defineProperty(minPlayersInput, 'value', {
+      configurable: true,
+      value: 'abc',
+    });
+    fireEvent.input(minPlayersInput);
+    fireEvent.change(maxPlayersInput, { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/player counts must be numbers/i)
+    ).not.toHaveLength(0);
+  });
+
   it('step 2 validates intensity is required', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
@@ -632,10 +789,10 @@ describe('CreateGame', () => {
       /public - anyone can see and join/i
     ) as HTMLSelectElement;
     fireEvent.change(visibilitySelect, { target: { value: 'friends' } });
-    expect(screen.getByText('Friends Only')).toBeInTheDocument();
+    expect(screen.getAllByText('Friends Only').length).toBeGreaterThan(0);
 
     fireEvent.change(visibilitySelect, { target: { value: 'invite' } });
-    expect(screen.getByText('Invite Only')).toBeInTheDocument();
+    expect(screen.getAllByText('Invite Only').length).toBeGreaterThan(0);
 
     const waitlistCheckbox = screen.getByLabelText(/enable waitlist/i) as HTMLInputElement;
     const checkInCheckbox = screen.getByLabelText(/require check-in/i) as HTMLInputElement;
@@ -699,6 +856,33 @@ describe('CreateGame', () => {
 
     expect(pushMock).toHaveBeenCalledWith('/login');
     expect(createGameMock).not.toHaveBeenCalled();
+  });
+
+  it('submit is ignored during cooldown on step 3', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    const createGameMock = jest.fn().mockResolvedValue({ gameId: 'cooldown-guard' });
+    mockUseCreateGame.mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep3();
+
+    // Still within the 1s cooldown set by the step transitions.
+    fireEvent.click(screen.getByRole('button', { name: /create game/i }));
+    expect(createGameMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create game/i }));
+    await waitFor(() => expect(createGameMock).toHaveBeenCalledTimes(1));
   });
 
   it('submit validates minAge must not exceed maxAge on final create', async () => {
@@ -1307,49 +1491,5 @@ describe('CreateGame', () => {
 
     fireEvent.click(redirectingButton);
     expect(createGameMock).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('isValidStep helper', () => {
-  it('validates required fields for step 1', () => {
-    const base = {
-      title: 'Game',
-      sport: 'Basketball',
-      location: 'Court',
-      date: '2026-02-10',
-      indoor: 'INDOOR',
-      startTime: '10:00',
-      endTime: '11:00',
-    };
-
-    expect(isValidStep(1, base)).toBe(true);
-    expect(isValidStep(1, { ...base, title: '' })).toBe(false);
-    expect(isValidStep(1, { ...base, sport: '' })).toBe(false);
-    expect(isValidStep(1, { ...base, location: '' })).toBe(false);
-    expect(isValidStep(1, { ...base, date: '' })).toBe(false);
-    expect(isValidStep(1, { ...base, indoor: '' })).toBe(false);
-    expect(isValidStep(1, { ...base, startTime: '' })).toBe(false);
-    expect(isValidStep(1, { ...base, endTime: '' })).toBe(false);
-  });
-
-  it('validates min/max players, skill and intensity for step 2', () => {
-    const base = {
-      minPlayers: '6',
-      maxPlayers: '10',
-      skillLevel: 'ALL_LEVELS',
-      intensity: 'CASUAL',
-    };
-
-    expect(isValidStep(2, base)).toBe(true);
-    expect(isValidStep(2, { ...base, minPlayers: '' })).toBe(false);
-    expect(isValidStep(2, { ...base, maxPlayers: '' })).toBe(false);
-    expect(isValidStep(2, { ...base, maxPlayers: '4' })).toBe(false);
-    expect(isValidStep(2, { ...base, skillLevel: '' })).toBe(false);
-    expect(isValidStep(2, { ...base, intensity: '' })).toBe(false);
-  });
-
-  it('returns true for step 3 and beyond', () => {
-    expect(isValidStep(3, {})).toBe(true);
-    expect(isValidStep(99, {})).toBe(true);
   });
 });

--- a/playlocal/frontend/test/components/CreateGame.test.tsx
+++ b/playlocal/frontend/test/components/CreateGame.test.tsx
@@ -9,7 +9,7 @@ import {
   within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { CreateGame } from '@/components/CreateGame';
+import { CreateGame, isValidStep } from '@/components/CreateGame';
 import { toast } from '@/lib/toast';
 
 // --------------------
@@ -448,6 +448,151 @@ describe('CreateGame', () => {
     ).not.toHaveLength(0);
   });
 
+  it('step 2 validates required fields: max players required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+
+    await goToStep2();
+    fireEvent.change(screen.getByPlaceholderText('e.g., 6'), {
+      target: { value: '6' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please enter maximum players/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('step 2 validates minimum players must be at least 2', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+
+    await goToStep2();
+    fireEvent.change(screen.getByPlaceholderText('e.g., 6'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g., 10'), {
+      target: { value: '4' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/minimum players must be at least 2/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('step 2 validates maximum players cannot be less than minimum', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+
+    await goToStep2();
+    fireEvent.change(screen.getByPlaceholderText('e.g., 6'), {
+      target: { value: '8' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g., 10'), {
+      target: { value: '6' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/maximum players cannot be less than minimum players/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('step 2 validates skill level is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+
+    await goToStep2();
+    fireEvent.change(screen.getByPlaceholderText('e.g., 6'), {
+      target: { value: '6' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g., 10'), {
+      target: { value: '10' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select a skill level/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('step 2 validates intensity is required', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+
+    await goToStep2();
+    fireEvent.change(screen.getByPlaceholderText('e.g., 6'), {
+      target: { value: '6' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('e.g., 10'), {
+      target: { value: '10' },
+    });
+
+    const selects = screen.getAllByRole('combobox') as HTMLSelectElement[];
+    const skill = selects.find((s) =>
+      Array.from(s.options).some((o) => o.textContent?.match(/select skill level/i))
+    );
+    if (!skill) throw new Error('Skill select not found');
+
+    fireEvent.change(skill, { target: { value: 'ALL_LEVELS' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findAllByText(/please select an intensity level/i)
+    ).not.toHaveLength(0);
+  });
+
   it('back button returns from step 2 to step 1', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
@@ -466,6 +611,173 @@ describe('CreateGame', () => {
     fireEvent.click(screen.getByRole('button', { name: /back/i }));
 
     expect(await screen.findByText(/basic information/i)).toBeInTheDocument();
+  });
+
+  it('step 3 settings update summary visibility and toggles', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 88 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep3();
+
+    const visibilitySelect = screen.getByDisplayValue(
+      /public - anyone can see and join/i
+    ) as HTMLSelectElement;
+    fireEvent.change(visibilitySelect, { target: { value: 'friends' } });
+    expect(screen.getByText('Friends Only')).toBeInTheDocument();
+
+    fireEvent.change(visibilitySelect, { target: { value: 'invite' } });
+    expect(screen.getByText('Invite Only')).toBeInTheDocument();
+
+    const waitlistCheckbox = screen.getByLabelText(/enable waitlist/i) as HTMLInputElement;
+    const checkInCheckbox = screen.getByLabelText(/require check-in/i) as HTMLInputElement;
+
+    expect(waitlistCheckbox.checked).toBe(true);
+    expect(checkInCheckbox.checked).toBe(true);
+
+    fireEvent.click(waitlistCheckbox);
+    fireEvent.click(checkInCheckbox);
+
+    expect(waitlistCheckbox.checked).toBe(false);
+    expect(checkInCheckbox.checked).toBe(false);
+  });
+
+  it('step 3 reliability clear resets value and summary label', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 88 },
+    });
+    mockUseCreateGame.mockReturnValue({
+      createGame: jest.fn(),
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep3();
+
+    const reliabilityInput = screen.getByLabelText(
+      /minimum reliability score/i
+    ) as HTMLInputElement;
+
+    fireEvent.change(reliabilityInput, { target: { value: '85' } });
+    expect(screen.getByText('85%')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+    expect(reliabilityInput.value).toBe('');
+    expect(screen.getByText(/none \(open to all\)/i)).toBeInTheDocument();
+  });
+
+  it('submitting on step 3 while unauthenticated redirects to login without creating', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, user: null });
+
+    const createGameMock = jest.fn();
+    mockUseCreateGame.mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep3();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create game/i }));
+
+    expect(pushMock).toHaveBeenCalledWith('/login');
+    expect(createGameMock).not.toHaveBeenCalled();
+  });
+
+  it('submit validates minAge must not exceed maxAge on final create', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    const createGameMock = jest.fn().mockResolvedValue({ gameId: 'should-not-create' });
+    mockUseCreateGame.mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep2();
+
+    fireEvent.change(screen.getByPlaceholderText(/minimum age/i), {
+      target: { value: '30' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/maximum age/i), {
+      target: { value: '18' },
+    });
+
+    await fillStep2Valid();
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await screen.findByText(/game settings/i);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create game/i }));
+
+    expect(
+      await screen.findAllByText(/minimum age cannot be greater than maximum age/i)
+    ).not.toHaveLength(0);
+    expect(createGameMock).not.toHaveBeenCalled();
+  });
+
+  it('includes description in payload when user fills it on step 2', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+    const createGameMock = jest.fn().mockResolvedValue({ gameId: 'with-description' });
+    mockUseCreateGame.mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep2();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/add any additional details about the game/i),
+      { target: { value: 'Bring a light jersey and water bottle.' } }
+    );
+
+    await fillStep2Valid();
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await screen.findByText(/game settings/i);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create game/i }));
+
+    await waitFor(() => {
+      expect(createGameMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'Bring a light jersey and water bottle.',
+        })
+      );
+    });
   });
 
   it('community tags: selecting and unselecting checkboxes updates checked state', async () => {
@@ -910,5 +1222,134 @@ describe('CreateGame', () => {
     expect(toast.error).toHaveBeenCalled();
     const banners = await screen.findAllByText(/nope\. Please try again\./i);
     expect(banners.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('submits only once when Create Game is clicked rapidly twice', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+
+    let resolveCreate: ((value: { gameId: string }) => void) | undefined;
+    const createGameMock = jest
+      .fn()
+      .mockImplementation(
+        () =>
+          new Promise<{ gameId: string }>((resolve) => {
+            resolveCreate = resolve;
+          })
+      );
+
+    mockUseCreateGame.mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep3();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const createButton = screen.getByRole('button', { name: /create game/i });
+    fireEvent.click(createButton);
+    fireEvent.click(createButton);
+
+    expect(createGameMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCreate?.({ gameId: 'single-submit-game' });
+    });
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/games/single-submit-game');
+    });
+  });
+
+  it('does not submit again after success while redirect is pending', async () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      user: { reliabilityScore: 80 },
+    });
+
+    const createGameMock = jest
+      .fn()
+      .mockResolvedValue({ gameId: 'already-created-game' });
+
+    mockUseCreateGame.mockReturnValue({
+      createGame: createGameMock,
+      isCreating: false,
+      error: null,
+    });
+    getTagsMock.mockResolvedValue([]);
+
+    render(<CreateGame />);
+    await goToStep3();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const createButton = screen.getByRole('button', { name: /create game/i });
+    fireEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/games/already-created-game');
+    });
+
+    const redirectingButton = screen.getByRole('button', {
+      name: /redirecting/i,
+    });
+    expect(redirectingButton).toBeDisabled();
+
+    fireEvent.click(redirectingButton);
+    expect(createGameMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isValidStep helper', () => {
+  it('validates required fields for step 1', () => {
+    const base = {
+      title: 'Game',
+      sport: 'Basketball',
+      location: 'Court',
+      date: '2026-02-10',
+      indoor: 'INDOOR',
+      startTime: '10:00',
+      endTime: '11:00',
+    };
+
+    expect(isValidStep(1, base)).toBe(true);
+    expect(isValidStep(1, { ...base, title: '' })).toBe(false);
+    expect(isValidStep(1, { ...base, sport: '' })).toBe(false);
+    expect(isValidStep(1, { ...base, location: '' })).toBe(false);
+    expect(isValidStep(1, { ...base, date: '' })).toBe(false);
+    expect(isValidStep(1, { ...base, indoor: '' })).toBe(false);
+    expect(isValidStep(1, { ...base, startTime: '' })).toBe(false);
+    expect(isValidStep(1, { ...base, endTime: '' })).toBe(false);
+  });
+
+  it('validates min/max players, skill and intensity for step 2', () => {
+    const base = {
+      minPlayers: '6',
+      maxPlayers: '10',
+      skillLevel: 'ALL_LEVELS',
+      intensity: 'CASUAL',
+    };
+
+    expect(isValidStep(2, base)).toBe(true);
+    expect(isValidStep(2, { ...base, minPlayers: '' })).toBe(false);
+    expect(isValidStep(2, { ...base, maxPlayers: '' })).toBe(false);
+    expect(isValidStep(2, { ...base, maxPlayers: '4' })).toBe(false);
+    expect(isValidStep(2, { ...base, skillLevel: '' })).toBe(false);
+    expect(isValidStep(2, { ...base, intensity: '' })).toBe(false);
+  });
+
+  it('returns true for step 3 and beyond', () => {
+    expect(isValidStep(3, {})).toBe(true);
+    expect(isValidStep(99, {})).toBe(true);
   });
 });

--- a/playlocal/frontend/test/hooks/useGames.test.ts
+++ b/playlocal/frontend/test/hooks/useGames.test.ts
@@ -197,6 +197,27 @@ describe('useGame', () => {
     expect(mockJoin).not.toHaveBeenCalled();
   });
 
+  it('joinGame throws when gamesApi.join is unavailable', async () => {
+    const originalJoin = (gamesApi as any).join;
+    (gamesApi as any).join = undefined;
+    mockGetById.mockResolvedValue(mockGame);
+    mockGetRoster.mockResolvedValue(mockRoster);
+
+    try {
+      const { result } = renderHook(() => useGame('game-123'));
+
+      await waitFor(() => {
+        expect(result.current.game).toEqual(mockGame);
+      });
+
+      await expect(async () => {
+        await result.current.joinGame();
+      }).rejects.toThrow('gamesApi.join is not available');
+    } finally {
+      (gamesApi as any).join = originalJoin;
+    }
+  });
+
   it('leaveGame calls API and refetches game', async () => {
     mockGetById.mockResolvedValue(mockGame);
     mockGetRoster.mockResolvedValue(mockRoster);
@@ -242,6 +263,27 @@ describe('useGame', () => {
       'Game ID required'
     );
     expect(mockLeave).not.toHaveBeenCalled();
+  });
+
+  it('leaveGame throws when gamesApi.leave is unavailable', async () => {
+    const originalLeave = (gamesApi as any).leave;
+    (gamesApi as any).leave = undefined;
+    mockGetById.mockResolvedValue(mockGame);
+    mockGetRoster.mockResolvedValue(mockRoster);
+
+    try {
+      const { result } = renderHook(() => useGame('game-123'));
+
+      await waitFor(() => {
+        expect(result.current.game).toEqual(mockGame);
+      });
+
+      await expect(async () => {
+        await result.current.leaveGame();
+      }).rejects.toThrow('gamesApi.leave is not available');
+    } finally {
+      (gamesApi as any).leave = originalLeave;
+    }
   });
 });
 
@@ -543,6 +585,54 @@ describe('useCreateGame', () => {
     expect(result.current.error).toBe('Failed to create game');
     await waitFor(() => expect(result.current.isCreating).toBe(false));
   });
+
+  it('deduplicates concurrent create requests', async () => {
+    const gameData = { title: 'New Game', sportName: 'Basketball' } as any;
+
+    let resolveCreate: ((value: any) => void) | undefined;
+    mockCreate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }) as any
+    );
+
+    const { result } = renderHook(() => require(hooksPath).useCreateGame());
+
+    let firstPromise: Promise<any>;
+    let secondPromise: Promise<any>;
+
+    await act(async () => {
+      firstPromise = result.current.createGame(gameData);
+      secondPromise = result.current.createGame(gameData);
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCreate?.(mockGame);
+      await Promise.all([firstPromise!, secondPromise!]);
+    });
+
+    await waitFor(() => expect(result.current.isCreating).toBe(false));
+  });
+
+  it('throws when gamesApi.create is unavailable', async () => {
+    const originalCreate = (gamesApi as any).create;
+    (gamesApi as any).create = undefined;
+
+    try {
+      const { result } = renderHook(() => require(hooksPath).useCreateGame());
+
+      await act(async () => {
+        await expect(
+          result.current.createGame({ title: 'Bad', sportName: 'Basketball' } as any)
+        ).rejects.toThrow('gamesApi.create is not available');
+      });
+    } finally {
+      (gamesApi as any).create = originalCreate;
+    }
+  });
 });
 
 describe('useGame - cancelGame', () => {
@@ -621,6 +711,27 @@ describe('useGame - cancelGame', () => {
     await expect(async () => {
       await result.current.cancelGame();
     }).rejects.toThrow('Game ID required');
+  });
+
+  it('throws error when gamesApi.cancel is unavailable', async () => {
+    const originalCancel = (gamesApi as any).cancel;
+    (gamesApi as any).cancel = undefined;
+    mockGetById.mockResolvedValue(mockGame);
+    mockGetRoster.mockResolvedValue(mockRoster);
+
+    try {
+      const { result } = renderHook(() => useGame('game-123'));
+
+      await waitFor(() => {
+        expect(result.current.game).toBeDefined();
+      });
+
+      await expect(async () => {
+        await result.current.cancelGame();
+      }).rejects.toThrow('gamesApi.cancel is not available');
+    } finally {
+      (gamesApi as any).cancel = originalCancel;
+    }
   });
 
   it('handles cancel failure gracefully', async () => {

--- a/playlocal/frontend/test/hooks/useGames.test.ts
+++ b/playlocal/frontend/test/hooks/useGames.test.ts
@@ -278,9 +278,11 @@ describe('useGame', () => {
         expect(result.current.game).toEqual(mockGame);
       });
 
-      await expect(async () => {
-        await result.current.leaveGame();
-      }).rejects.toThrow('gamesApi.leave is not available');
+      await expect(
+        act(async () => {
+          await result.current.leaveGame();
+        })
+      ).rejects.toThrow('gamesApi.leave is not available');
     } finally {
       (gamesApi as any).leave = originalLeave;
     }


### PR DESCRIPTION
### BUG FIX
Fix duplicate game creation by preventing concurrent Create Game submissions

Fixes: #351  


### PR Description
Summary
This PR fixes a bug where rapidly clicking Create Game could create multiple games.

### Root Cause
The create flow relied on UI timing and allowed duplicate submits in fast-click and redirect timing windows.

### What Changed
Added submit locking in the Create Game flow so only the first submit is processed.
Disabled the Create Game action while a request is in progress and during redirect.
Added hook-level deduplication so concurrent create calls reuse the same in-flight request instead of sending multiple POSTs.
Simplified the implementation by removing redundant local state.

### Tests
Added/updated regression tests for:
rapid multi-click submit attempts
post-success redirect-window clicks
concurrent create calls at the hook level

### Result
Users can click multiple times, but only one game is created.

### Addressing the 3 bugs in the bug issue #351 

1. I cannot enter the game page even though it appears that it exists in discover game page. -> has already been fixed in pr #354 
2. During game creation, the date field is not mobile responsive. -> The current UI uses each browser/phone’s default date picker. It is better to keep it this way to avoid unnecessary code additions.
3. I clicked the create game button many times and it created many games (duplicate) -> this PR fixes that issue.