### PR TITLE
365 clarify game participation status in calendar view

### DIFF
--- a/playlocal/frontend/components/CalendarView.tsx
+++ b/playlocal/frontend/components/CalendarView.tsx
@@ -3,12 +3,9 @@ import Link from 'next/link';
 import {
   ChevronLeft,
   ChevronRight,
-  Calendar as CalendarIcon,
   MapPin,
-  Users,
   Clock,
   Plus,
-  Loader2,
   X,
 } from 'lucide-react';
 import { useGames } from '@/hooks/useGames';
@@ -38,8 +35,53 @@ interface CalendarGame {
   time: string;
   location: string;
   sport: string;
-  status: string;
   role: string;
+  /** Confirmed participant (not host); matches API hasExactLocationAccess for RSVP’d members. */
+  isConfirmedMember: boolean;
+}
+
+type CalendarGameStyleInput = Pick<CalendarGame, 'role' | 'isConfirmedMember'>;
+
+/**
+ * Card colors aligned with MapView pins: emerald = exact/joined, amber = approximate / not joined.
+ */
+function calendarGameCardSurfaceClass(game: CalendarGameStyleInput): string {
+  if (game.role === 'host') {
+    return 'border-purple-200/60 bg-purple-50/60 hover:bg-purple-100/60';
+  }
+  if (game.isConfirmedMember) {
+    return 'border-emerald-200/60 bg-emerald-50/60 hover:bg-emerald-100/60';
+  }
+  return 'border-amber-200/65 bg-amber-50/35 hover:bg-amber-50/55';
+}
+
+/** Small month-cell chips. */
+function calendarGameChipClass(game: CalendarGameStyleInput): string {
+  if (game.role === 'host') {
+    return 'bg-purple-100 text-purple-700 hover:bg-purple-200';
+  }
+  if (game.isConfirmedMember) {
+    return 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200';
+  }
+  return 'bg-amber-50 text-amber-800 hover:bg-amber-100/80';
+}
+
+const goingBadgeClassName =
+  'px-2 py-0.5 bg-emerald-100 text-emerald-700 text-xs rounded';
+
+function CalendarGameRoleBadges({ game }: { game: CalendarGame }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {game.role === 'host' && (
+        <span className="px-2 py-0.5 bg-purple-100 text-purple-700 text-xs rounded">
+          Host
+        </span>
+      )}
+      {game.isConfirmedMember && (
+        <span className={goingBadgeClassName}>Going</span>
+      )}
+    </div>
+  );
 }
 
 export function CalendarView() {
@@ -47,26 +89,34 @@ export function CalendarView() {
   const [view, setView] = useState<'month' | 'week' | 'day'>('month');
   const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [overlayVisible, setOverlayVisible] = useState(false);
-  const { games: apiGames, isLoading } = useGames();
-  const { user, isAuthenticated } = useAuth();
+  const { games: apiGames } = useGames();
+  const { user } = useAuth();
   const isMobile = useIsMobile();
 
   // Transform API games to calendar format
   const games: CalendarGame[] = useMemo(() => {
     if (apiGames && apiGames.length > 0) {
-      return apiGames.map((game) => ({
-        id: game.gameId,
-        title: game.title,
-        date: new Date(game.startTime),
-        time: new Date(game.startTime).toLocaleTimeString('en-US', {
-          hour: 'numeric',
-          minute: '2-digit',
-        }),
-        location: game.location?.name || 'TBD',
-        sport: game.sportName,
-        status: 'confirmed',
-        role: game.organizer?.userId === user?.userId ? 'host' : 'participant',
-      }));
+      return apiGames.map((game) => {
+        const isHost = game.organizer?.userId === user?.userId;
+        const isConfirmedMember = Boolean(
+          user?.userId &&
+            game.hasExactLocationAccess &&
+            !isHost
+        );
+        return {
+          id: game.gameId,
+          title: game.title,
+          date: new Date(game.startTime),
+          time: new Date(game.startTime).toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+          }),
+          location: game.location?.name || 'TBD',
+          sport: game.sportName,
+          role: isHost ? 'host' : 'participant',
+          isConfirmedMember,
+        };
+      });
     }
     return [];
   }, [apiGames, user]);
@@ -299,13 +349,9 @@ export function CalendarView() {
                                 <Link
                                   key={game.id}
                                   href={`/games/${game.id}`}
-                                  className={`block px-2 py-1 text-xs rounded truncate ${
-                                    game.role === 'host'
-                                      ? 'bg-purple-100 text-purple-700 hover:bg-purple-200'
-                                      : game.status === 'tentative'
-                                        ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
-                                        : 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200'
-                                  } transition-colors`}
+                                  className={`block px-2 py-1 text-xs rounded truncate ${calendarGameChipClass(
+                                    game
+                                  )} transition-colors`}
                                 >
                                   {game.time} {game.sport}
                                 </Link>
@@ -340,15 +386,13 @@ export function CalendarView() {
                     <Link
                       key={game.id}
                       href={`/games/${game.id}`}
-                      className="block p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+                      className={`block p-3 rounded-lg border transition-colors ${calendarGameCardSurfaceClass(
+                        game
+                      )}`}
                     >
-                      <div className="flex items-start justify-between mb-2">
+                      <div className="flex items-start justify-between gap-2 mb-2">
                         <div className="text-gray-900">{game.sport}</div>
-                        {game.role === 'host' && (
-                          <span className="px-2 py-0.5 bg-purple-100 text-purple-700 text-xs rounded">
-                            Host
-                          </span>
-                        )}
+                        <CalendarGameRoleBadges game={game} />
                       </div>
                       <div className="text-sm text-gray-600 mb-1">
                         {game.title}
@@ -377,16 +421,20 @@ export function CalendarView() {
               <h3 className="text-lg text-gray-900 mb-4">Legend</h3>
               <div className="space-y-2">
                 <div className="flex items-center gap-3">
-                  <div className="w-4 h-4 bg-emerald-100 rounded"></div>
-                  <span className="text-sm text-gray-700">Confirmed</span>
+                  <div className="w-4 h-4 rounded border border-amber-200/75 bg-amber-50/90" />
+                  <span className="text-sm text-gray-700">
+                    Not joined or waitlist (orange pins on map)
+                  </span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <div className="w-4 h-4 bg-amber-100 rounded"></div>
-                  <span className="text-sm text-gray-700">Waitlist</span>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-4 h-4 bg-purple-100 rounded"></div>
+                  <div className="w-4 h-4 bg-purple-100 rounded border border-purple-200" />
                   <span className="text-sm text-gray-700">Hosting</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="w-4 h-4 bg-emerald-100 rounded border border-emerald-200" />
+                  <span className="text-sm text-gray-700">
+                    Going / joined (green pins on map)
+                  </span>
                 </div>
               </div>
             </div>
@@ -461,21 +509,13 @@ export function CalendarView() {
                     <Link
                       key={game.id}
                       href={`/games/${game.id}`}
-                      className={`block p-3 rounded-xl border transition-colors ${
-                        game.role === 'host'
-                          ? 'border-purple-200/60 bg-purple-50/60 hover:bg-purple-100/60'
-                          : game.status === 'tentative'
-                            ? 'border-amber-200/60 bg-amber-50/60 hover:bg-amber-100/60'
-                            : 'border-emerald-200/60 bg-emerald-50/60 hover:bg-emerald-100/60'
-                      }`}
+                      className={`block p-3 rounded-xl border transition-colors ${calendarGameCardSurfaceClass(
+                        game
+                      )}`}
                     >
-                      <div className="flex items-center justify-between mb-1">
+                      <div className="flex items-center justify-between gap-2 mb-1">
                         <span className="font-medium text-gray-900">{game.sport}</span>
-                        {game.role === 'host' && (
-                          <span className="px-2 py-0.5 bg-purple-100 text-purple-700 text-xs rounded">
-                            Host
-                          </span>
-                        )}
+                        <CalendarGameRoleBadges game={game} />
                       </div>
                       <div className="text-sm text-gray-600 mb-2">{game.title}</div>
                       <div className="flex items-center gap-2 text-xs text-gray-500">

--- a/playlocal/frontend/components/CalendarView.tsx
+++ b/playlocal/frontend/components/CalendarView.tsx
@@ -112,7 +112,7 @@ export function CalendarView() {
             hour: 'numeric',
             minute: '2-digit',
           }),
-          location: game.location?.name || 'TBD',
+          location: game.location?.name ?? game.approximateLocation ?? 'TBD',
           sport: game.sportName,
           role: isHost ? 'host' : 'participant',
           isConfirmedMember,

--- a/playlocal/frontend/components/CalendarView.tsx
+++ b/playlocal/frontend/components/CalendarView.tsx
@@ -103,11 +103,12 @@ export function CalendarView() {
             game.hasExactLocationAccess &&
             !isHost
         );
+        const startTime = new Date(game.startTime);
         return {
           id: game.gameId,
           title: game.title,
-          date: new Date(game.startTime),
-          time: new Date(game.startTime).toLocaleTimeString('en-US', {
+          date: startTime,
+          time: startTime.toLocaleTimeString('en-US', {
             hour: 'numeric',
             minute: '2-digit',
           }),

--- a/playlocal/frontend/test/components/CalendarView.test.tsx
+++ b/playlocal/frontend/test/components/CalendarView.test.tsx
@@ -419,7 +419,7 @@ describe('CalendarView', () => {
       user: { userId: 'u1' },
       isAuthenticated: true,
     });
-    mockUseGames.mockReturnValue({ games: undefined as unknown as [], isLoading: false });
+    mockUseGames.mockReturnValue({ games: undefined, isLoading: false });
 
     const { rerender } = render(<CalendarView />);
     expect(screen.queryByRole('link', { name: /gym/i })).not.toBeInTheDocument();

--- a/playlocal/frontend/test/components/CalendarView.test.tsx
+++ b/playlocal/frontend/test/components/CalendarView.test.tsx
@@ -426,7 +426,8 @@ describe('CalendarView', () => {
 
     mockUseGames.mockReturnValue({ games: [], isLoading: false });
     rerender(<CalendarView />);
-    expect(screen.getByText('Upcoming Games')).toBeInTheDocument();
+    // Still no upcoming game links when the API returns an explicit empty array
+    expect(screen.queryByRole('link', { name: /gym/i })).not.toBeInTheDocument();
   });
 
   it('on mobile, shows single-letter weekday headers and opens day overlay with games', () => {

--- a/playlocal/frontend/test/components/CalendarView.test.tsx
+++ b/playlocal/frontend/test/components/CalendarView.test.tsx
@@ -1,6 +1,6 @@
 // __tests__/components/CalendarView.test.tsx
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CalendarView } from '@/components/CalendarView';
 
@@ -13,6 +13,11 @@ jest.mock('@/hooks/useGames', () => ({
 const mockUseAuth = jest.fn();
 jest.mock('@/context/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+const mockUseIsMobile = jest.fn(() => false);
+jest.mock('@/components/ui/use-mobile', () => ({
+  useIsMobile: () => mockUseIsMobile(),
 }));
 
 // next/link -> render as <a> so we can assert href/text
@@ -29,12 +34,10 @@ jest.mock('next/link', () => {
 jest.mock('lucide-react', () => ({
   ChevronLeft: (props: any) => <svg data-testid="ChevronLeft" {...props} />,
   ChevronRight: (props: any) => <svg data-testid="ChevronRight" {...props} />,
-  Calendar: (props: any) => <svg data-testid="Calendar" {...props} />,
   MapPin: (props: any) => <svg data-testid="MapPin" {...props} />,
-  Users: (props: any) => <svg data-testid="Users" {...props} />,
   Clock: (props: any) => <svg data-testid="Clock" {...props} />,
   Plus: (props: any) => <svg data-testid="Plus" {...props} />,
-  Loader2: (props: any) => <svg data-testid="Loader2" {...props} />,
+  X: (props: any) => <svg data-testid="X" {...props} />,
 }));
 
 // Helper: build a local date string reliably
@@ -50,14 +53,24 @@ function isoLocal(
 }
 
 describe('CalendarView', () => {
+  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(2026, 1, 9, 12, 0, 0)); // Feb 9, 2026 @ 12:00
     mockUseGames.mockReset();
     mockUseAuth.mockReset();
+    mockUseIsMobile.mockReturnValue(false);
+    rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
   });
 
   afterEach(() => {
+    rafSpy.mockRestore();
     jest.useRealTimers();
   });
 
@@ -160,6 +173,10 @@ describe('CalendarView', () => {
     fireEvent.click(dayBtn);
     expect(dayBtn.className).toMatch(/bg-emerald-100/);
     expect(weekBtn.className).not.toMatch(/bg-emerald-100/);
+
+    fireEvent.click(monthBtn);
+    expect(monthBtn.className).toMatch(/bg-emerald-100/);
+    expect(dayBtn.className).not.toMatch(/bg-emerald-100/);
   });
 
   it('maps API games into calendar games and shows them in Upcoming Games (sorted, future only, limit 5)', () => {
@@ -358,5 +375,201 @@ describe('CalendarView', () => {
         el.className.includes('rounded-full')
     );
     expect(todayBadge).toBeTruthy();
+  });
+
+  it('shows Going badge for confirmed participants (hasExactLocationAccess, not host)', () => {
+    mockUseAuth.mockReturnValue({
+      user: { userId: 'player-1' },
+      isAuthenticated: true,
+    });
+    mockUseGames.mockReturnValue({
+      games: [
+        {
+          gameId: 'joined-1',
+          title: 'Pickup Run',
+          startTime: isoLocal(2026, 1, 15, 10, 0),
+          sportName: 'Basketball',
+          organizer: { userId: 'organizer-1' },
+          location: { name: 'Court 1' },
+          hasExactLocationAccess: true,
+        },
+        {
+          gameId: 'browse-1',
+          title: 'Open Run',
+          startTime: isoLocal(2026, 1, 16, 10, 0),
+          sportName: 'Soccer',
+          organizer: { userId: 'organizer-2' },
+          location: { name: 'Field A' },
+          hasExactLocationAccess: false,
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<CalendarView />);
+
+    const going = screen.getAllByText('Going');
+    expect(going.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Pickup Run')).toBeInTheDocument();
+    expect(screen.getByText('Open Run')).toBeInTheDocument();
+  });
+
+  it('treats missing or empty API games as an empty calendar game list', () => {
+    mockUseAuth.mockReturnValue({
+      user: { userId: 'u1' },
+      isAuthenticated: true,
+    });
+    mockUseGames.mockReturnValue({ games: undefined as unknown as [], isLoading: false });
+
+    const { rerender } = render(<CalendarView />);
+    expect(screen.queryByRole('link', { name: /gym/i })).not.toBeInTheDocument();
+
+    mockUseGames.mockReturnValue({ games: [], isLoading: false });
+    rerender(<CalendarView />);
+    expect(screen.getByText('Upcoming Games')).toBeInTheDocument();
+  });
+
+  it('on mobile, shows single-letter weekday headers and opens day overlay with games', () => {
+    mockUseIsMobile.mockReturnValue(true);
+    mockUseAuth.mockReturnValue({
+      user: { userId: 'u1' },
+      isAuthenticated: true,
+    });
+    mockUseGames.mockReturnValue({
+      games: [
+        {
+          gameId: 'mob-1',
+          title: 'Morning Run',
+          startTime: isoLocal(2026, 1, 10, 9, 0),
+          sportName: 'Running',
+          organizer: { userId: 'other' },
+          location: { name: 'Park' },
+          hasExactLocationAccess: false,
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<CalendarView />);
+
+    // Compact mobile headers: single-letter abbreviations (e.g. Mon → M)
+    expect(screen.getByText('M')).toBeInTheDocument();
+    expect(screen.getByText('F')).toBeInTheDocument();
+
+    const dayButton = screen.getByRole('button', { name: /10 1 game/i });
+    fireEvent.click(dayButton);
+
+    const title = screen.getByRole('heading', { name: /Tuesday, February 10/i });
+    expect(title).toBeInTheDocument();
+    const modalShell = title.closest('.overflow-hidden');
+    expect(modalShell).toBeTruthy();
+    expect(within(modalShell!).getByText('Morning Run')).toBeInTheDocument();
+    expect(within(modalShell!).getByText('Running')).toBeInTheDocument();
+  });
+
+  it('on mobile, closes day overlay via close button, backdrop, and Escape', () => {
+    mockUseIsMobile.mockReturnValue(true);
+    mockUseAuth.mockReturnValue({
+      user: { userId: 'u1' },
+      isAuthenticated: true,
+    });
+    mockUseGames.mockReturnValue({
+      games: [
+        {
+          gameId: 'close-test',
+          title: 'Soccer Pickup',
+          startTime: isoLocal(2026, 1, 11, 15, 0),
+          sportName: 'Soccer',
+          organizer: { userId: 'x' },
+          location: { name: 'Field' },
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<CalendarView />);
+
+    const openModal = () =>
+      fireEvent.click(screen.getByRole('button', { name: /11 1 game/i }));
+
+    openModal();
+    const dayTitle = screen.getByRole('heading', {
+      name: /Wednesday, February 11/i,
+    });
+    const modalShell = dayTitle.closest('.overflow-hidden');
+    expect(modalShell).toBeTruthy();
+    expect(within(modalShell!).getByText('Soccer Pickup')).toBeInTheDocument();
+
+    fireEvent.click(within(modalShell!).getByTestId('X').closest('button')!);
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(
+      screen.queryByRole('heading', { name: /Wednesday, February 11/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText('Soccer Pickup')).toHaveLength(1);
+
+    openModal();
+    expect(
+      screen.getByRole('heading', { name: /Wednesday, February 11/i })
+    ).toBeInTheDocument();
+    const overlayRoot = screen
+      .getByRole('heading', { name: /Wednesday, February 11/i })
+      .closest('.fixed');
+    expect(overlayRoot).toBeTruthy();
+    fireEvent.click(overlayRoot!);
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(
+      screen.queryByRole('heading', { name: /Wednesday, February 11/i })
+    ).not.toBeInTheDocument();
+
+    openModal();
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(
+      screen.queryByRole('heading', { name: /Wednesday, February 11/i })
+    ).not.toBeInTheDocument();
+
+    openModal();
+    const presentation = screen
+      .getByRole('heading', { name: /Wednesday, February 11/i })
+      .closest('[role="presentation"]')!;
+    fireEvent.keyDown(presentation, { key: 'Escape', code: 'Escape' });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(
+      screen.queryByRole('heading', { name: /Wednesday, February 11/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show Going badge for host games (Host badge only)', () => {
+    mockUseAuth.mockReturnValue({
+      user: { userId: 'organizer-1' },
+      isAuthenticated: true,
+    });
+    mockUseGames.mockReturnValue({
+      games: [
+        {
+          gameId: 'mine',
+          title: 'My Game',
+          startTime: isoLocal(2026, 1, 15, 10, 0),
+          sportName: 'Tennis',
+          organizer: { userId: 'organizer-1' },
+          location: { name: 'Club' },
+          hasExactLocationAccess: true,
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<CalendarView />);
+
+    expect(screen.getByText('Host')).toBeInTheDocument();
+    expect(screen.queryByText('Going')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# BUG FIX
Update calendar game styling and labels to clearly indicate if a user is hosting, joined ("Going"), or browsing. This aligns the calendar color scheme with the map view pins—using emerald for confirmed attendance, amber for approximate locations/unjoined games, and purple for hosted games.

Fixes #365


## Screenshots
<img width="386" height="908" alt="image" src="https://github.com/user-attachments/assets/1e090bc5-70e1-422f-9d98-f0ac1587158a" />



